### PR TITLE
[TEST] Fix ecosystem/orchestrator.ts branch coverage (50% → 100%)

### DIFF
--- a/tests/ecosystem/ecosystem-orchestrator.test.ts
+++ b/tests/ecosystem/ecosystem-orchestrator.test.ts
@@ -8,6 +8,27 @@ import type { ScanReport } from '../../src/types/index.js';
 vi.mock('node:fs');
 const mockedFs = vi.mocked(fs);
 
+// Mock ZeroDBClient so no real network calls occur
+vi.mock('../../src/integrations/zerodb-client.js', () => {
+  const ZeroDBClient = vi.fn().mockImplementation(() => ({
+    vectorSearch: vi.fn().mockResolvedValue([]),
+    vectorUpsert: vi.fn().mockResolvedValue(undefined),
+  }));
+  return { ZeroDBClient };
+});
+
+// Mock corpus builder to track upsertRepoProfile calls
+vi.mock('../../src/ecosystem/corpus-builder.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../src/ecosystem/corpus-builder.js')>();
+  return {
+    ...original,
+    upsertRepoProfile: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+import { ZeroDBClient } from '../../src/integrations/zerodb-client.js';
+import * as corpusBuilder from '../../src/ecosystem/corpus-builder.js';
+
 function makeReport(): ScanReport {
   return {
     repo: 'acme/scanner',
@@ -103,5 +124,116 @@ describe('EcosystemOrchestrator', () => {
   it('disclaimer is present and non-empty', async () => {
     const intel = await orchestrator.analyze(makeContext());
     expect(intel.disclaimer.length).toBeGreaterThan(20);
+  });
+
+  describe('zerodbAvailable=true branch', () => {
+    function makeZerodbContext(overrides: Partial<EcosystemContext> = {}): EcosystemContext {
+      return makeContext({
+        zerodbAvailable: true,
+        config: {
+          maturity: null, depth: ScanDepth.STANDARD, format: OutputFormat.JSON,
+          output: null, threshold: null, quiet: false, verbose: false, scannerTimeout: 30000,
+          githubToken: null,
+          zerodbApiKey: 'test-api-key',
+          zerodbProjectId: 'test-project-id',
+          pillars: { disabled: [], weights: {}, disabledScanners: [] },
+          bots: { enabled: true, additional: [], exclude: [] },
+          inclusive: { termListUrl: null, customTerms: {}, ignoredTerms: [], excludePatterns: [] },
+        },
+        ...overrides,
+      });
+    }
+
+    beforeEach(() => {
+      vi.mocked(ZeroDBClient).mockClear();
+      vi.mocked(corpusBuilder.upsertRepoProfile).mockClear();
+    });
+
+    it('constructs ZeroDBClient when zerodbAvailable=true with valid key and projectId', async () => {
+      await orchestrator.analyze(makeZerodbContext());
+      expect(vi.mocked(ZeroDBClient)).toHaveBeenCalledOnce();
+      expect(vi.mocked(ZeroDBClient)).toHaveBeenCalledWith(
+        expect.any(String),
+        'test-api-key',
+        'test-project-id',
+      );
+    });
+
+    it('does not construct ZeroDBClient when apiKey is missing', async () => {
+      const ctx = makeContext({
+        zerodbAvailable: true,
+        config: {
+          maturity: null, depth: ScanDepth.STANDARD, format: OutputFormat.JSON,
+          output: null, threshold: null, quiet: false, verbose: false, scannerTimeout: 30000,
+          githubToken: null,
+          zerodbApiKey: null,
+          zerodbProjectId: 'test-project-id',
+          pillars: { disabled: [], weights: {}, disabledScanners: [] },
+          bots: { enabled: true, additional: [], exclude: [] },
+          inclusive: { termListUrl: null, customTerms: {}, ignoredTerms: [], excludePatterns: [] },
+        },
+      });
+      await orchestrator.analyze(ctx);
+      expect(vi.mocked(ZeroDBClient)).not.toHaveBeenCalled();
+    });
+
+    it('does not construct ZeroDBClient when projectId is missing', async () => {
+      const ctx = makeContext({
+        zerodbAvailable: true,
+        config: {
+          maturity: null, depth: ScanDepth.STANDARD, format: OutputFormat.JSON,
+          output: null, threshold: null, quiet: false, verbose: false, scannerTimeout: 30000,
+          githubToken: null,
+          zerodbApiKey: 'test-api-key',
+          zerodbProjectId: null,
+          pillars: { disabled: [], weights: {}, disabledScanners: [] },
+          bots: { enabled: true, additional: [], exclude: [] },
+          inclusive: { termListUrl: null, customTerms: {}, ignoredTerms: [], excludePatterns: [] },
+        },
+      });
+      await orchestrator.analyze(ctx);
+      expect(vi.mocked(ZeroDBClient)).not.toHaveBeenCalled();
+    });
+
+    it('calls upsertRepoProfile when ZeroDBClient is constructed', async () => {
+      await orchestrator.analyze(makeZerodbContext());
+      // upsertRepoProfile is fire-and-forget; allow microtasks to flush
+      await Promise.resolve();
+      expect(vi.mocked(corpusBuilder.upsertRepoProfile)).toHaveBeenCalledOnce();
+    });
+
+    it('returns static dataSource when zerodbAvailable=true but no vector hits', async () => {
+      // vectorSearch returns [] by default — zero hits → static
+      const intel = await orchestrator.analyze(makeZerodbContext());
+      expect(intel.dataSource).toBe('static');
+    });
+
+    it('returns zerodb-assisted when 1–9 rivals have a non-null similarityScore', async () => {
+      // Make vectorSearch return a single hit so one rival gets a non-null score
+      vi.mocked(ZeroDBClient).mockImplementationOnce(() => ({
+        vectorSearch: vi.fn().mockResolvedValue([
+          { id: 'other/repo', score: 0.9, metadata: { name: 'Other Repo', repo: 'other/repo', repoUrl: null, tags: [] } },
+        ]),
+        vectorUpsert: vi.fn().mockResolvedValue(undefined),
+      }));
+      orchestrator = new EcosystemOrchestrator();
+      const intel = await orchestrator.analyze(makeZerodbContext());
+      expect(intel.dataSource).toBe('zerodb-assisted');
+    });
+
+    it('returns zerodb-full when 10+ rivals have a non-null similarityScore', async () => {
+      const hits = Array.from({ length: 10 }, (_, i) => ({
+        id: `org/repo-${i}`,
+        score: 0.85,
+        metadata: { name: `Repo ${i}`, repo: `org/repo-${i}`, repoUrl: null, tags: [] },
+      }));
+      vi.mocked(ZeroDBClient).mockImplementationOnce(() => ({
+        vectorSearch: vi.fn().mockResolvedValue(hits),
+        vectorUpsert: vi.fn().mockResolvedValue(undefined),
+      }));
+      orchestrator = new EcosystemOrchestrator();
+      const intel = await orchestrator.analyze(makeZerodbContext());
+      expect(intel.dataSource).toBe('zerodb-full');
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Added tests to `tests/ecosystem/ecosystem-orchestrator.test.ts` covering all three uncovered branch clusters
- Branch coverage: **50% → 100%**
- No source changes needed

## Branches covered
- Lines 32-39: `zerodbAvailable=true` + ZeroDB client construction; missing key/projectId false branch
- Lines 54-55: `upsertRepoProfile` called when ZeroDB client constructed (corpus indexing)
- Lines 74-78: `resolveDataSource` — `zerodb-full` (≥10 vector hits), `zerodb-assisted` (1 hit), `static` (0 hits)

## Test plan
- [x] Red commit `e96e5ec` — tests targeting uncovered branches
- [x] Green commit `58677a3` — all tests pass, 100% branch coverage
- [x] Branch ≥ 80% for `src/ecosystem/orchestrator.ts`

Closes #19