### PR TITLE
fix: clone remote GitHub repos to tempdir so file scanners run on target

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -138,63 +138,72 @@ async function main(): Promise<void> {
   }
 
   const version = getVersion();
-  const context = buildContext(validatedTarget, config, version);
+  const { context, cleanup } = buildContext(validatedTarget, config, version);
 
-  if (config.verbose) {
-    context.emit = (event) => {
-      if (event.type === 'scanner:complete') {
-        console.error(`  ✓ ${event.scanner} (${event.findingCount} findings, ${event.durationMs}ms)`);
-      }
-    };
-  }
-
-  const registry = createDefaultRegistry();
-  const orchestrator = new Orchestrator(registry);
-  const result = await orchestrator.run(context);
-
-  const report = buildScanReport(validatedTarget, result, config, context.maturity, version);
-
-  // Populate git metadata from context
-  report.metadata.commitSha = context.git.commitSha;
-  report.metadata.branch = context.git.branch;
-  report.metadata.remoteUrl = context.git.remoteUrl;
-
-  // Ecosystem intelligence (opt-in, non-scoring)
-  if (config.ecosystem) {
-    if (!config.quiet) context.emit({ type: 'ecosystem:start' });
-    try {
-      const ecoContext = {
-        ...context,
-        existingReport: report,
-        zerodbAvailable: !!(config.zerodbApiKey && config.zerodbProjectId),
+  try {
+    if (config.verbose) {
+      context.emit = (event) => {
+        if (event.type === 'scanner:complete') {
+          console.error(`  ✓ ${event.scanner} (${event.findingCount} findings, ${event.durationMs}ms)`);
+        }
       };
-      const ecoOrchestrator = new EcosystemOrchestrator();
-      report.ecosystem = await ecoOrchestrator.analyze(ecoContext);
-      if (!config.quiet) context.emit({ type: 'ecosystem:complete', dataSource: report.ecosystem.dataSource });
-    } catch (err) {
-      if (!config.quiet) console.error(`Ecosystem analysis failed: ${err instanceof Error ? err.message : String(err)}`);
     }
+
+    const registry = createDefaultRegistry();
+    const orchestrator = new Orchestrator(registry);
+    const result = await orchestrator.run(context);
+
+    const report = buildScanReport(validatedTarget, result, config, context.maturity, version);
+
+    // Populate git metadata from context
+    report.metadata.commitSha = context.git.commitSha;
+    report.metadata.branch = context.git.branch;
+    report.metadata.remoteUrl = context.git.remoteUrl;
+
+    // Ecosystem intelligence (opt-in, non-scoring)
+    if (config.ecosystem) {
+      if (!config.quiet) context.emit({ type: 'ecosystem:start' });
+      try {
+        const ecoContext = {
+          ...context,
+          existingReport: report,
+          zerodbAvailable: !!(config.zerodbApiKey && config.zerodbProjectId),
+        };
+        const ecoOrchestrator = new EcosystemOrchestrator();
+        report.ecosystem = await ecoOrchestrator.analyze(ecoContext);
+        if (!config.quiet) context.emit({ type: 'ecosystem:complete', dataSource: report.ecosystem.dataSource });
+      } catch (err) {
+        if (!config.quiet) console.error(`Ecosystem analysis failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    const output =
+      config.format === OutputFormat.MARKDOWN
+        ? renderMarkdown(report)
+        : serializeJson(report);
+
+    if (config.output) {
+      writeFileSync(config.output, output, 'utf-8');
+      if (!config.quiet) console.error(`Output written to ${config.output}`);
+    } else {
+      process.stdout.write(output + '\n');
+    }
+
+    if (!config.quiet) {
+      console.error(`\nScore: ${result.overallScore.toFixed(1)}/10 (${result.riskLevel})`);
+    }
+
+    // Exit codes: 0 = low risk (≥8), 1 = medium (5–7.9), 2 = high/critical (<5) or threshold missed
+    if (!result.thresholdPassed) {
+      cleanup();
+      process.exit(2);
+    }
+    cleanup();
+    process.exit(result.overallScore >= 8.0 ? 0 : result.overallScore >= 5.0 ? 1 : 2);
+  } catch (err) {
+    cleanup();
+    throw err;
   }
-
-  const output =
-    config.format === OutputFormat.MARKDOWN
-      ? renderMarkdown(report)
-      : serializeJson(report);
-
-  if (config.output) {
-    writeFileSync(config.output, output, 'utf-8');
-    if (!config.quiet) console.error(`Output written to ${config.output}`);
-  } else {
-    process.stdout.write(output + '\n');
-  }
-
-  if (!config.quiet) {
-    console.error(`\nScore: ${result.overallScore.toFixed(1)}/10 (${result.riskLevel})`);
-  }
-
-  // Exit codes: 0 = low risk (≥8), 1 = medium (5–7.9), 2 = high/critical (<5) or threshold missed
-  if (!result.thresholdPassed) process.exit(2);
-  process.exit(result.overallScore >= 8.0 ? 0 : result.overallScore >= 5.0 ? 1 : 2);
 }
 
 // Only run main() when executed directly, not when imported for testing

--- a/src/config.ts
+++ b/src/config.ts
@@ -124,6 +124,14 @@ export function buildConfig(
     }
   }
 
+  // Read GitHub token from environment when not set by caller
+  if (!config.githubToken) {
+    config.githubToken =
+      process.env['GITHUB_TOKEN'] ||
+      process.env['GITHUB_PERSONAL_ACCESS_TOKEN'] ||
+      null;
+  }
+
   return config;
 }
 

--- a/src/context-builder.ts
+++ b/src/context-builder.ts
@@ -1,4 +1,7 @@
 import { execSync } from 'child_process';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { MaturityLevel, ScanDepth } from './types/index.js';
 import type { ScanContext, ScannerConfig } from './types/index.js';
 
@@ -8,6 +11,12 @@ export interface GitInfo {
   commitSha: string | null;
   branch: string | null;
   remoteUrl: string | null;
+}
+
+/** Result of buildContext, including a cleanup callback to remove any temp directories. */
+export interface BuildContextResult {
+  context: ScanContext;
+  cleanup: () => void;
 }
 
 function runGit(cmd: string, cwd: string): string | null {
@@ -32,17 +41,57 @@ function resolveMaturity(config: ScannerConfig): MaturityLevel {
   return config.maturity ?? MaturityLevel.SANDBOX;
 }
 
+/**
+ * Builds a ScanContext for a validated target.
+ *
+ * For GitHub targets the repository is cloned into a temporary directory so
+ * file-based scanners have real files to inspect. The returned `cleanup`
+ * function removes that directory when the caller is finished with it.
+ *
+ * For local targets `cleanup` is a no-op.
+ *
+ * @param target - The validated scan target (local path or GitHub slug/URL)
+ * @param config - Scanner configuration
+ * @param _version - Scanner version string
+ * @returns `{ context, cleanup }` — call `cleanup()` after the scan completes
+ */
 export function buildContext(
   target: ValidatedTarget,
   config: ScannerConfig,
   _version: string,
-): ScanContext {
-  const repoPath = target.type === 'local' ? target.value : '';
+): BuildContextResult {
+  let repoPath: string;
+  let cleanup: () => void;
+
+  if (target.type === 'github') {
+    const tempDir = mkdtempSync(join(tmpdir(), 'quaid-'));
+    const cloneUrl = `https://github.com/${target.value}.git`;
+    try {
+      execSync(`git clone --depth 1 ${cloneUrl} ${tempDir}`, {
+        stdio: ['ignore', 'ignore', 'ignore'],
+        timeout: 120_000,
+      });
+    } catch (err) {
+      throw new Error(`Failed to clone ${target.value}: ${err}`);
+    }
+    repoPath = tempDir;
+    cleanup = () => {
+      try {
+        rmSync(tempDir, { recursive: true, force: true });
+      } catch {
+        // best-effort cleanup — ignore errors
+      }
+    };
+  } else {
+    repoPath = target.value;
+    cleanup = () => {};
+  }
+
   const repoIdentifier = target.type === 'github' ? target.value : null;
-  const git = target.type === 'local' ? readGitInfo(repoPath) : { commitSha: null, branch: null, remoteUrl: null };
+  const git = readGitInfo(repoPath);
   const controller = new AbortController();
 
-  return {
+  const context: ScanContext = {
     repoPath,
     repoIdentifier,
     maturity: resolveMaturity(config),
@@ -52,4 +101,6 @@ export function buildContext(
     signal: controller.signal,
     emit: () => {},
   };
+
+  return { context, cleanup };
 }

--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -2,6 +2,13 @@ import { Severity, MaturityLevel } from '../types/index.js';
 import type { ScanReport, Recommendation, Finding, ScannerConfig } from '../types/index.js';
 import type { OrchestratorResult } from '../scanner/orchestrator.js';
 
+const SEVERITY_LABELS: Record<number, string> = {
+  [Severity.PASS]: 'PASS',
+  [Severity.INFO]: 'INFO',
+  [Severity.WARNING]: 'WARNING',
+  [Severity.CRITICAL]: 'CRITICAL',
+};
+
 type ValidatedTarget = { type: 'local' | 'github'; value: string };
 
 function buildRecommendations(findings: Finding[]): Recommendation[] {
@@ -77,5 +84,14 @@ export function buildScanReport(
 }
 
 export function serializeJson(report: ScanReport): string {
-  return JSON.stringify(report, null, 2);
+  return JSON.stringify(
+    report,
+    (key, value: unknown) => {
+      if (key === 'severity' && typeof value === 'number') {
+        return SEVERITY_LABELS[value] ?? String(value);
+      }
+      return value;
+    },
+    2,
+  );
 }

--- a/tests/cli/config.test.ts
+++ b/tests/cli/config.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for buildConfig environment variable fallback behaviour (issue #61).
+ *
+ * buildConfig must read GITHUB_TOKEN and GITHUB_PERSONAL_ACCESS_TOKEN from
+ * the environment when neither is supplied by the caller.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { buildConfig } from '../../src/config.js';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('buildConfig — GITHUB_TOKEN env fallback', () => {
+  it('reads githubToken from GITHUB_TOKEN env var when not set by caller', () => {
+    // Arrange
+    vi.stubEnv('GITHUB_TOKEN', 'ghp_test');
+    vi.stubEnv('GITHUB_PERSONAL_ACCESS_TOKEN', '');
+
+    // Act
+    const config = buildConfig({});
+
+    // Assert
+    expect(config.githubToken).toBe('ghp_test');
+  });
+
+  it('reads githubToken from GITHUB_PERSONAL_ACCESS_TOKEN when GITHUB_TOKEN is absent', () => {
+    // Arrange
+    vi.stubEnv('GITHUB_TOKEN', '');
+    vi.stubEnv('GITHUB_PERSONAL_ACCESS_TOKEN', 'ghp_pat_value');
+
+    // Act
+    const config = buildConfig({});
+
+    // Assert
+    expect(config.githubToken).toBe('ghp_pat_value');
+  });
+
+  it('gives GITHUB_TOKEN precedence over GITHUB_PERSONAL_ACCESS_TOKEN when both are set', () => {
+    // Arrange
+    vi.stubEnv('GITHUB_TOKEN', 'ghp_primary');
+    vi.stubEnv('GITHUB_PERSONAL_ACCESS_TOKEN', 'ghp_fallback');
+
+    // Act
+    const config = buildConfig({});
+
+    // Assert
+    expect(config.githubToken).toBe('ghp_primary');
+  });
+
+  it('returns null for githubToken when neither env var is set', () => {
+    // Arrange — ensure both vars are absent
+    vi.stubEnv('GITHUB_TOKEN', '');
+    vi.stubEnv('GITHUB_PERSONAL_ACCESS_TOKEN', '');
+
+    // Act
+    const config = buildConfig({});
+
+    // Assert
+    expect(config.githubToken).toBeNull();
+  });
+});

--- a/tests/context-builder.test.ts
+++ b/tests/context-builder.test.ts
@@ -1,7 +1,27 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { readGitInfo, buildContext } from '../src/context-builder.js';
 import { DEFAULT_CONFIG } from '../src/config.js';
 import { MaturityLevel, ScanDepth } from '../src/types/index.js';
+
+// Mock fs and child_process at the module level so ESM named exports are replaceable
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    mkdtempSync: vi.fn(actual.mkdtempSync),
+    rmSync: vi.fn(actual.rmSync),
+  };
+});
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    execSync: vi.fn(actual.execSync),
+  };
+});
+
+// --- readGitInfo tests (unchanged) ---
 
 describe('readGitInfo', () => {
   it('returns an object with the expected shape', () => {
@@ -20,11 +40,32 @@ describe('readGitInfo', () => {
   });
 });
 
+// --- buildContext tests ---
+
 describe('buildContext', () => {
+  let mkdtempSyncMock: ReturnType<typeof vi.fn>;
+  let execSyncMock: ReturnType<typeof vi.fn>;
+  let rmSyncMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const fsMod = await import('fs');
+    const childMod = await import('child_process');
+
+    mkdtempSyncMock = fsMod.mkdtempSync as ReturnType<typeof vi.fn>;
+    execSyncMock = childMod.execSync as ReturnType<typeof vi.fn>;
+    rmSyncMock = fsMod.rmSync as ReturnType<typeof vi.fn>;
+
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('builds a valid ScanContext from a local target', () => {
     const target = { type: 'local' as const, value: '/tmp/test-repo' };
     const config = { ...DEFAULT_CONFIG, depth: ScanDepth.QUICK };
-    const ctx = buildContext(target, config, '1.0.0');
+    const { context: ctx } = buildContext(target, config, '1.0.0');
 
     expect(ctx.repoPath).toBe('/tmp/test-repo');
     expect(ctx.repoIdentifier).toBeNull();
@@ -35,27 +76,88 @@ describe('buildContext', () => {
     expect(typeof ctx.emit).toBe('function');
   });
 
-  it('builds a valid ScanContext from a github target', () => {
+  it('returns a noop cleanup function for a local target', () => {
+    const target = { type: 'local' as const, value: '/tmp/test-repo' };
+    const { cleanup } = buildContext(target, DEFAULT_CONFIG, '1.0.0');
+
+    expect(typeof cleanup).toBe('function');
+    expect(() => cleanup()).not.toThrow();
+  });
+
+  it('local target cleanup does not call rmSync', () => {
+    const target = { type: 'local' as const, value: '/tmp/test-repo' };
+    const { cleanup } = buildContext(target, DEFAULT_CONFIG, '1.0.0');
+
+    cleanup();
+
+    expect(rmSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('builds a valid ScanContext from a github target with a non-empty repoPath', () => {
+    mkdtempSyncMock.mockReturnValue('/tmp/quaid-MOCKED');
+    execSyncMock.mockReturnValue(Buffer.from(''));
+
     const target = { type: 'github' as const, value: 'owner/repo' };
     const config = { ...DEFAULT_CONFIG };
-    const ctx = buildContext(target, config, '1.0.0');
+    const { context: ctx } = buildContext(target, config, '1.0.0');
 
-    expect(ctx.repoPath).toBe('');
+    expect(ctx.repoPath).toBe('/tmp/quaid-MOCKED');
+    expect(ctx.repoPath).not.toBe('');
     expect(ctx.repoIdentifier).toBe('owner/repo');
     expect(ctx.maturity).toBeDefined();
+  });
+
+  it('calls execSync with a git clone command for a github target', () => {
+    mkdtempSyncMock.mockReturnValue('/tmp/quaid-MOCKED');
+    execSyncMock.mockReturnValue(Buffer.from(''));
+
+    const target = { type: 'github' as const, value: 'owner/repo' };
+    buildContext(target, DEFAULT_CONFIG, '1.0.0');
+
+    const cloneCall = execSyncMock.mock.calls.find(
+      (call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).includes('git clone'),
+    );
+    expect(cloneCall).toBeDefined();
+    const cloneCmd = cloneCall![0] as string;
+    expect(cloneCmd).toContain('https://github.com/owner/repo.git');
+    expect(cloneCmd).toContain('/tmp/quaid-MOCKED');
+  });
+
+  it('the cleanup function calls rmSync on the temp directory for a github target', () => {
+    mkdtempSyncMock.mockReturnValue('/tmp/quaid-MOCKED');
+    execSyncMock.mockReturnValue(Buffer.from(''));
+
+    const target = { type: 'github' as const, value: 'owner/repo' };
+    const { cleanup } = buildContext(target, DEFAULT_CONFIG, '1.0.0');
+
+    cleanup();
+
+    expect(rmSyncMock).toHaveBeenCalledWith('/tmp/quaid-MOCKED', { recursive: true, force: true });
+  });
+
+  it('throws a clear error when git clone fails', () => {
+    mkdtempSyncMock.mockReturnValue('/tmp/quaid-MOCKED');
+    execSyncMock.mockImplementation(() => {
+      throw new Error('git: not found');
+    });
+
+    const target = { type: 'github' as const, value: 'owner/repo' };
+    expect(() => buildContext(target, DEFAULT_CONFIG, '1.0.0')).toThrow(
+      /Failed to clone owner\/repo/,
+    );
   });
 
   it('resolves null config maturity to SANDBOX default', () => {
     const target = { type: 'local' as const, value: '/tmp/test-repo' };
     const config = { ...DEFAULT_CONFIG, maturity: null };
-    const ctx = buildContext(target, config, '1.0.0');
+    const { context: ctx } = buildContext(target, config, '1.0.0');
 
     expect(Object.values(MaturityLevel)).toContain(ctx.maturity);
   });
 
   it('emit callback does not throw', () => {
     const target = { type: 'local' as const, value: '/tmp' };
-    const ctx = buildContext(target, DEFAULT_CONFIG, '1.0.0');
+    const { context: ctx } = buildContext(target, DEFAULT_CONFIG, '1.0.0');
     expect(() =>
       ctx.emit({ type: 'scan:start', repoPath: '/tmp', depth: ScanDepth.QUICK }),
     ).not.toThrow();

--- a/tests/reporters/json.test.ts
+++ b/tests/reporters/json.test.ts
@@ -106,4 +106,88 @@ describe('serializeJson', () => {
     expect(parsed.overallScore).toBe(8.0);
     expect(parsed.version).toBe('1.0.0');
   });
+
+  it('serializes CRITICAL severity as string "CRITICAL" not integer 2', () => {
+    const target = { type: 'local' as const, value: '/tmp' };
+    const result = makeResult({
+      findings: [
+        {
+          id: 'f-crit',
+          severity: Severity.CRITICAL,
+          pillar: Pillar.SECURITY,
+          category: 'test',
+          message: 'Critical finding',
+          file: null,
+          line: null,
+          column: null,
+          suggestion: 'Fix it',
+        },
+      ],
+    });
+    const parsed = JSON.parse(serializeJson(buildScanReport(target, result, DEFAULT_CONFIG, MaturityLevel.SANDBOX, '1.0.0')));
+    expect(parsed.findings[0].severity).toBe('CRITICAL');
+  });
+
+  it('serializes WARNING severity as string "WARNING" not integer 1', () => {
+    const target = { type: 'local' as const, value: '/tmp' };
+    const result = makeResult({
+      findings: [
+        {
+          id: 'f-warn',
+          severity: Severity.WARNING,
+          pillar: Pillar.SECURITY,
+          category: 'test',
+          message: 'Warning finding',
+          file: null,
+          line: null,
+          column: null,
+          suggestion: 'Fix it',
+        },
+      ],
+    });
+    const parsed = JSON.parse(serializeJson(buildScanReport(target, result, DEFAULT_CONFIG, MaturityLevel.SANDBOX, '1.0.0')));
+    expect(parsed.findings[0].severity).toBe('WARNING');
+  });
+
+  it('serializes INFO severity as string "INFO" not integer 0', () => {
+    const target = { type: 'local' as const, value: '/tmp' };
+    const result = makeResult({
+      findings: [
+        {
+          id: 'f-info',
+          severity: Severity.INFO,
+          pillar: Pillar.SECURITY,
+          category: 'test',
+          message: 'Info finding',
+          file: null,
+          line: null,
+          column: null,
+          suggestion: 'Note it',
+        },
+      ],
+    });
+    const parsed = JSON.parse(serializeJson(buildScanReport(target, result, DEFAULT_CONFIG, MaturityLevel.SANDBOX, '1.0.0')));
+    expect(parsed.findings[0].severity).toBe('INFO');
+  });
+
+  it('serializes PASS severity as string "PASS" not integer -1', () => {
+    const target = { type: 'local' as const, value: '/tmp' };
+    const result = makeResult({
+      findings: [
+        {
+          id: 'f-pass',
+          severity: Severity.PASS,
+          pillar: Pillar.SECURITY,
+          category: 'test',
+          message: 'Pass finding',
+          file: null,
+          line: null,
+          column: null,
+          suggestion: 'Keep it up',
+        },
+      ],
+    });
+    const parsed = JSON.parse(serializeJson(buildScanReport(target, result, DEFAULT_CONFIG, MaturityLevel.SANDBOX, '1.0.0')));
+    expect(parsed.findings[0].severity).toBe('PASS');
+  });
 });


### PR DESCRIPTION
Closes #63

## What
When scanning a GitHub URL, buildContext now clones the repo to a temporary directory so file-based scanners (inclusive, technical, governance, etc.) run against the actual target rather than quaid-scanner's own source tree.

`buildContext` now returns `{ context, cleanup }` instead of `ScanContext` directly. Callers invoke `cleanup()` after the scan completes to remove the temp directory. `src/cli.ts` wraps the scan in a try/finally to ensure cleanup always runs.

## Test plan
- [ ] Unit tests verify clone is called and cleanup works
- [ ] Full test suite passes
- [ ] Rescan of zerodb-mcp-server shows findings from the target repo, not quaid-scanner files