### PR TITLE
fix: buildConfig reads GITHUB_TOKEN / GITHUB_PERSONAL_ACCESS_TOKEN from env

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -124,6 +124,14 @@ export function buildConfig(
     }
   }
 
+  // Read GitHub token from environment when not set by caller
+  if (!config.githubToken) {
+    config.githubToken =
+      process.env['GITHUB_TOKEN'] ||
+      process.env['GITHUB_PERSONAL_ACCESS_TOKEN'] ||
+      null;
+  }
+
   return config;
 }
 

--- a/tests/cli/config.test.ts
+++ b/tests/cli/config.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for buildConfig environment variable fallback behaviour (issue #61).
+ *
+ * buildConfig must read GITHUB_TOKEN and GITHUB_PERSONAL_ACCESS_TOKEN from
+ * the environment when neither is supplied by the caller.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { buildConfig } from '../../src/config.js';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('buildConfig — GITHUB_TOKEN env fallback', () => {
+  it('reads githubToken from GITHUB_TOKEN env var when not set by caller', () => {
+    // Arrange
+    vi.stubEnv('GITHUB_TOKEN', 'ghp_test');
+    vi.stubEnv('GITHUB_PERSONAL_ACCESS_TOKEN', '');
+
+    // Act
+    const config = buildConfig({});
+
+    // Assert
+    expect(config.githubToken).toBe('ghp_test');
+  });
+
+  it('reads githubToken from GITHUB_PERSONAL_ACCESS_TOKEN when GITHUB_TOKEN is absent', () => {
+    // Arrange
+    vi.stubEnv('GITHUB_TOKEN', '');
+    vi.stubEnv('GITHUB_PERSONAL_ACCESS_TOKEN', 'ghp_pat_value');
+
+    // Act
+    const config = buildConfig({});
+
+    // Assert
+    expect(config.githubToken).toBe('ghp_pat_value');
+  });
+
+  it('gives GITHUB_TOKEN precedence over GITHUB_PERSONAL_ACCESS_TOKEN when both are set', () => {
+    // Arrange
+    vi.stubEnv('GITHUB_TOKEN', 'ghp_primary');
+    vi.stubEnv('GITHUB_PERSONAL_ACCESS_TOKEN', 'ghp_fallback');
+
+    // Act
+    const config = buildConfig({});
+
+    // Assert
+    expect(config.githubToken).toBe('ghp_primary');
+  });
+
+  it('returns null for githubToken when neither env var is set', () => {
+    // Arrange — ensure both vars are absent
+    vi.stubEnv('GITHUB_TOKEN', '');
+    vi.stubEnv('GITHUB_PERSONAL_ACCESS_TOKEN', '');
+
+    // Act
+    const config = buildConfig({});
+
+    // Assert
+    expect(config.githubToken).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #61

## What
Read `GITHUB_TOKEN` (falling back to `GITHUB_PERSONAL_ACCESS_TOKEN`) from environment in `buildConfig` so scanner API checks work without a `--github-token` flag.

Previously `config.githubToken` was always `null` because `buildConfig` only merged CLI options over defaults and never consulted `process.env`. All GitHub API-backed scanner checks silently skipped, producing security/community scores of 0.

## Test plan
- [x] `GITHUB_TOKEN` in env → `config.githubToken` equals that value
- [x] `GITHUB_PERSONAL_ACCESS_TOKEN` set (no `GITHUB_TOKEN`) → PAT value used
- [x] Both set → `GITHUB_TOKEN` takes precedence
- [x] Neither set → `null` (preserves previous default)
- [x] Full test suite passes (1289 existing tests unaffected)