### PR TITLE
fix: serialize finding severity as string label not integer

### DIFF
--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -2,6 +2,13 @@ import { Severity, MaturityLevel } from '../types/index.js';
 import type { ScanReport, Recommendation, Finding, ScannerConfig } from '../types/index.js';
 import type { OrchestratorResult } from '../scanner/orchestrator.js';
 
+const SEVERITY_LABELS: Record<number, string> = {
+  [Severity.PASS]: 'PASS',
+  [Severity.INFO]: 'INFO',
+  [Severity.WARNING]: 'WARNING',
+  [Severity.CRITICAL]: 'CRITICAL',
+};
+
 type ValidatedTarget = { type: 'local' | 'github'; value: string };
 
 function buildRecommendations(findings: Finding[]): Recommendation[] {
@@ -77,5 +84,14 @@ export function buildScanReport(
 }
 
 export function serializeJson(report: ScanReport): string {
-  return JSON.stringify(report, null, 2);
+  return JSON.stringify(
+    report,
+    (key, value: unknown) => {
+      if (key === 'severity' && typeof value === 'number') {
+        return SEVERITY_LABELS[value] ?? String(value);
+      }
+      return value;
+    },
+    2,
+  );
 }

--- a/tests/reporters/json.test.ts
+++ b/tests/reporters/json.test.ts
@@ -106,4 +106,88 @@ describe('serializeJson', () => {
     expect(parsed.overallScore).toBe(8.0);
     expect(parsed.version).toBe('1.0.0');
   });
+
+  it('serializes CRITICAL severity as string "CRITICAL" not integer 2', () => {
+    const target = { type: 'local' as const, value: '/tmp' };
+    const result = makeResult({
+      findings: [
+        {
+          id: 'f-crit',
+          severity: Severity.CRITICAL,
+          pillar: Pillar.SECURITY,
+          category: 'test',
+          message: 'Critical finding',
+          file: null,
+          line: null,
+          column: null,
+          suggestion: 'Fix it',
+        },
+      ],
+    });
+    const parsed = JSON.parse(serializeJson(buildScanReport(target, result, DEFAULT_CONFIG, MaturityLevel.SANDBOX, '1.0.0')));
+    expect(parsed.findings[0].severity).toBe('CRITICAL');
+  });
+
+  it('serializes WARNING severity as string "WARNING" not integer 1', () => {
+    const target = { type: 'local' as const, value: '/tmp' };
+    const result = makeResult({
+      findings: [
+        {
+          id: 'f-warn',
+          severity: Severity.WARNING,
+          pillar: Pillar.SECURITY,
+          category: 'test',
+          message: 'Warning finding',
+          file: null,
+          line: null,
+          column: null,
+          suggestion: 'Fix it',
+        },
+      ],
+    });
+    const parsed = JSON.parse(serializeJson(buildScanReport(target, result, DEFAULT_CONFIG, MaturityLevel.SANDBOX, '1.0.0')));
+    expect(parsed.findings[0].severity).toBe('WARNING');
+  });
+
+  it('serializes INFO severity as string "INFO" not integer 0', () => {
+    const target = { type: 'local' as const, value: '/tmp' };
+    const result = makeResult({
+      findings: [
+        {
+          id: 'f-info',
+          severity: Severity.INFO,
+          pillar: Pillar.SECURITY,
+          category: 'test',
+          message: 'Info finding',
+          file: null,
+          line: null,
+          column: null,
+          suggestion: 'Note it',
+        },
+      ],
+    });
+    const parsed = JSON.parse(serializeJson(buildScanReport(target, result, DEFAULT_CONFIG, MaturityLevel.SANDBOX, '1.0.0')));
+    expect(parsed.findings[0].severity).toBe('INFO');
+  });
+
+  it('serializes PASS severity as string "PASS" not integer -1', () => {
+    const target = { type: 'local' as const, value: '/tmp' };
+    const result = makeResult({
+      findings: [
+        {
+          id: 'f-pass',
+          severity: Severity.PASS,
+          pillar: Pillar.SECURITY,
+          category: 'test',
+          message: 'Pass finding',
+          file: null,
+          line: null,
+          column: null,
+          suggestion: 'Keep it up',
+        },
+      ],
+    });
+    const parsed = JSON.parse(serializeJson(buildScanReport(target, result, DEFAULT_CONFIG, MaturityLevel.SANDBOX, '1.0.0')));
+    expect(parsed.findings[0].severity).toBe('PASS');
+  });
 });


### PR DESCRIPTION
Closes #62

## What
`serializeJson` now emits severity as a human-readable string (CRITICAL, WARNING, INFO, PASS) instead of the raw enum integer. A custom `JSON.stringify` replacer intercepts `severity` keys at the serialization boundary, leaving internal code unchanged — the `Severity` enum continues to be used throughout scanners, orchestrator, and report building.

## Test plan
- [x] Unit tests verify all four severity values serialize correctly (PASS=-1, INFO=0, WARNING=1, CRITICAL=2)
- [x] Existing `serializeJson` tests (valid JSON, round-trip) still pass
- [x] Full test suite passes with no new failures