### PR TITLE
Add community health files, issue templates, and Prerequisites section

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,54 @@
+name: Bug Report
+description: Something isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please fill out the fields below so we can reproduce and fix the issue.
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `quaid-scanner --version`
+      placeholder: "0.1.1"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: The exact commands or inputs that trigger the bug.
+      placeholder: |
+        1. Run `quaid-scanner . --depth quick --format json`
+        2. See error in output...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Node.js version, OS, and any relevant env vars (no secrets).
+      placeholder: |
+        Node: 20.11.0
+        OS: macOS 14.4
+        GITHUB_TOKEN set: yes/no

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: GitHub Discussions (questions and ideas)
+    url: https://github.com/quaid/quaid-scanner/discussions
+    about: Ask questions, share use cases, and discuss ideas here.
+  - name: Security Vulnerability (private disclosure)
+    url: https://github.com/quaid/quaid-scanner/security/advisories/new
+    about: Report security vulnerabilities privately — do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/false_positive.yml
+++ b/.github/ISSUE_TEMPLATE/false_positive.yml
@@ -1,0 +1,51 @@
+name: False Positive
+description: quaid-scanner flagged something that should not be a finding
+labels: ["false-positive", "bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        False positives help us improve scanner accuracy. Please provide as much detail as possible so we can reproduce and fix the issue.
+
+  - type: input
+    id: finding-id
+    attributes:
+      label: Finding ID
+      description: The `id` field from the JSON finding (e.g. `INC-001`, `SEC-003`)
+      placeholder: "INC-001"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What file, pattern, repo, or configuration triggered the finding?
+      placeholder: |
+        File: src/utils/abort-handler.ts
+        Pattern matched: "abort" in `signal.aborted`
+    validations:
+      required: true
+
+  - type: textarea
+    id: why-fp
+    attributes:
+      label: Why is this a false positive?
+      description: Explain why this finding is incorrect for your case.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `quaid-scanner --version`
+      placeholder: "0.1.1"
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix (optional)
+      description: If you have an idea for how to fix the false positive, share it here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+name: Feature Request
+description: Propose a new scanner, metric, or capability
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. The more context you provide, the easier it is to evaluate the request.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or gap
+      description: What health signal is missing or incorrectly measured?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What should quaid-scanner do differently or additionally?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you considered, if any.
+
+  - type: dropdown
+    id: pillar
+    attributes:
+      label: Affected pillar
+      description: Which scoring pillar would this touch?
+      options:
+        - Security
+        - Governance
+        - Community
+        - AI Readiness
+        - Inclusive Language
+        - Technical Rigor
+        - Cross-pillar / new pillar
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: prior-art
+    attributes:
+      label: Prior art or reference
+      description: Links to CHAOSS metrics, OpenSSF criteria, or other frameworks that define this signal, if any.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,52 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release published to npm is supported with security fixes.
+
+| Version | Supported |
+| ------- | --------- |
+| 0.1.1 (latest) | Yes |
+| < 0.1.1 | No |
+
+Upgrade to the latest release before reporting a vulnerability.
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities using GitHub Security Advisories:
+
+https://github.com/quaid/quaid-scanner/security/advisories/new
+
+You will need a GitHub account. The advisory form lets you describe the vulnerability privately before any public disclosure.
+
+### What to Include
+
+A useful report includes:
+
+- **Version affected** — output of `quaid-scanner --version`
+- **Steps to reproduce** — the exact commands or inputs that trigger the issue
+- **Impact** — what an attacker could do, and under what conditions
+- **Suggested fix** — optional, but appreciated if you have one
+
+The more detail you provide, the faster we can respond.
+
+## Response Timeline
+
+- **Triage**: within 7 days of receiving the report
+- **Fix or mitigation**: within 30 days of triage
+
+If the timeline cannot be met, we will communicate that in the advisory thread.
+
+## Out of Scope
+
+The following are not treated as security vulnerabilities in this project:
+
+- **Theoretical vulnerabilities** without a working proof of concept
+- **Vulnerabilities in dependencies** — report those to the upstream project directly; we will update our dependencies when fixes are available
+- **Scanner false positives** — quaid-scanner producing an incorrect finding is a bug, not a security issue; open a [false positive issue](https://github.com/quaid/quaid-scanner/issues/new?template=false_positive.yml) instead
+
+## Disclosure Policy
+
+We follow coordinated disclosure. Once a fix is released, we will publish the advisory publicly and credit the reporter (unless you prefer to remain anonymous).

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,49 @@
+# Support
+
+## Getting Help
+
+### GitHub Discussions
+
+For questions, ideas, and general discussion, use [GitHub Discussions](https://github.com/quaid/quaid-scanner/discussions).
+
+Discussions are the right place for:
+
+- "How do I scan a private GitHub repo?"
+- "What does the OSPO-001 finding mean and how do I fix it?"
+- "How should I interpret a score of 3.2 for an incubation candidate?"
+- "My agent workflow is producing unexpected output — where should I look?"
+
+### GitHub Issues
+
+For confirmed bugs, use [GitHub Issues](https://github.com/quaid/quaid-scanner/issues/new/choose).
+
+Before opening an issue, search existing issues and discussions to avoid duplicates. Include the output of `quaid-scanner --version` in any bug report.
+
+### Security Vulnerabilities
+
+Do **not** open a public issue for security vulnerabilities. Report them privately using [GitHub Security Advisories](https://github.com/quaid/quaid-scanner/security/advisories/new). See [SECURITY.md](SECURITY.md) for the full disclosure policy and response timeline.
+
+### False Positives
+
+If quaid-scanner flags something incorrectly, open a [false positive issue](https://github.com/quaid/quaid-scanner/issues/new?template=false_positive.yml). False positives are bugs, not noise — they help us improve scanner accuracy.
+
+---
+
+## Documentation
+
+- [README](README.md) — installation, quickstart, full CLI reference, MCP server setup
+- [PRD](docs/PRD-v2.md) — product requirements, epic and story breakdown, implementation status
+- [CHANGELOG](CHANGELOG.md) — version history and migration notes
+
+---
+
+## Response Time
+
+This is a volunteer-maintained open source project. Response times are best-effort:
+
+| Channel | Expected response |
+| --- | --- |
+| GitHub Discussions | Days to weeks |
+| Bug issues | Weeks |
+| Feature requests | No guarantee; depends on roadmap fit |
+| Security reports | Within 7 days (see SECURITY.md) |

--- a/README.md
+++ b/README.md
@@ -20,6 +20,21 @@ Built on [OpenSSF Scorecard](https://securityscorecards.dev/), [CHAOSS metrics](
 
 ---
 
+## Prerequisites
+
+| Requirement | Version | Notes |
+| --- | --- | --- |
+| [Node.js](https://nodejs.org) | ≥ 18.0.0 | Required |
+| [Git](https://git-scm.com) | any | Required for local repo scanning |
+| GitHub token | — | Optional — unlocks branch protection checks, OpenSSF Scorecard API, and issue/PR metrics |
+| [ZeroDB](https://github.com/ainative-studio/zerodb) | local instance | Optional — required for scan history, trend tracking, and OSS social graph |
+
+**GitHub token:** set either `GITHUB_TOKEN` or `GITHUB_PERSONAL_ACCESS_TOKEN` in your environment. A classic token with `public_repo` scope is sufficient for public repos. The token is never written to disk.
+
+**ZeroDB:** set `ZERODB_API_URL`, `ZERODB_API_KEY`, and `ZERODB_PROJECT_ID`. Without ZeroDB, scanning and reporting work normally — persistence and graph features are silently skipped.
+
+---
+
 ## Install
 
 ```bash
@@ -31,8 +46,6 @@ Or run without installing:
 ```bash
 npx quaid-scanner . --depth quick
 ```
-
-**Requirements:** Node.js ≥ 18, Git
 
 ---
 


### PR DESCRIPTION
## Summary

- `.github/SECURITY.md` — vulnerability disclosure policy, supported versions, response timeline (#78)
- `.github/SUPPORT.md` — help channels, docs index, response time expectations (#80)
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues, links to Discussions and Security Advisories (#81)
- `.github/ISSUE_TEMPLATE/bug_report.yml` — structured form with version, repro steps, environment (#81)
- `.github/ISSUE_TEMPLATE/feature_request.yml` — structured form with pillar selector and prior-art field (#81)
- `.github/ISSUE_TEMPLATE/false_positive.yml` — structured form with finding ID, context, and suggested fix (#81)
- `README.md` — expanded inline "Requirements" one-liner into a full Prerequisites table with GitHub token and ZeroDB notes (#82)

Note: SECURITY.md and SUPPORT.md are in `.github/` rather than repo root because the pre-commit hook enforces no root `.md` files (except README.md). GitHub recognizes both locations.

Closes #78, #80, #81, #82