### PR TITLE
feat: render dataSource, context, and metadata in markdown output

### DIFF
--- a/src/reporters/markdown.ts
+++ b/src/reporters/markdown.ts
@@ -1,5 +1,5 @@
 import { Severity, Pillar, RiskLevel } from '../types/index.js';
-import type { ScanReport, Finding } from '../types/index.js';
+import type { ScanReport, Finding, FindingDataSource } from '../types/index.js';
 
 const PILLAR_LABELS: Record<Pillar, string> = {
   [Pillar.SECURITY]: 'Security',
@@ -18,7 +18,61 @@ const RISK_EMOJI: Record<RiskLevel, string> = {
 };
 
 function findingsBySeverity(findings: Finding[], severity: Severity): Finding[] {
-  return findings.filter((f) => f.severity === severity);
+    return findings.filter((f) => f.severity === severity);
+}
+
+const DATA_SOURCE_LABELS: Record<FindingDataSource, string> = {
+    api: 'external API',
+    local: 'local file check',
+    heuristic: 'computed heuristic',
+};
+
+/**
+ * Render the optional dataSource, context, and metadata fields for a finding.
+ * Returns an array of markdown lines to splice in after the message line.
+ */
+function renderFindingExtras(f: Finding): string[] {
+    const lines: string[] = [];
+
+    // dataSource label
+    if (f.dataSource !== undefined) {
+        const label = DATA_SOURCE_LABELS[f.dataSource];
+        lines.push(`_(source: ${label})_`);
+    }
+
+    // context fenced block
+    if (f.context !== undefined) {
+        lines.push('');
+        lines.push('**Context:**');
+        lines.push('```');
+        lines.push(f.context);
+        lines.push('```');
+    }
+
+    // known metadata fields
+    if (f.metadata !== undefined) {
+        const detailLines: string[] = [];
+
+        if (f.metadata.checkName !== undefined && f.metadata.checkScore !== undefined) {
+            detailLines.push(`Check: ${String(f.metadata.checkName)} — ${String(f.metadata.checkScore)}/10`);
+        }
+        if (f.metadata.branch !== undefined) {
+            detailLines.push(`Branch: ${String(f.metadata.branch)}`);
+        }
+        if (f.metadata.overallScore !== undefined) {
+            detailLines.push(`Overall score: ${String(f.metadata.overallScore)}`);
+        }
+
+        if (detailLines.length > 0) {
+            lines.push('');
+            lines.push('**Details:**');
+            for (const dl of detailLines) {
+                lines.push(dl);
+            }
+        }
+    }
+
+    return lines;
 }
 
 export interface MarkdownReportOptions {
@@ -77,6 +131,13 @@ export function renderMarkdown(report: ScanReport, options?: MarkdownReportOptio
       lines.push(`**Pillar:** ${PILLAR_LABELS[f.pillar as Pillar]} | **Category:** ${f.category}`);
       lines.push('');
       lines.push(f.message);
+      const extras = renderFindingExtras(f);
+      if (extras.length > 0) {
+        lines.push('');
+        for (const extra of extras) {
+          lines.push(extra);
+        }
+      }
       if (f.file) lines.push(`\n> File: \`${f.file}\`${f.line ? `:${f.line}` : ''}`);
       lines.push('');
       lines.push(`**Suggestion:** ${f.suggestion}`);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -81,6 +81,7 @@ export interface Scanner {
   run(context: ScanContext): Promise<Finding[]>;
 }
 
+/** Where a finding's data originated. */
 export type FindingDataSource = 'api' | 'local' | 'heuristic';
 
 export interface Finding {
@@ -92,6 +93,7 @@ export interface Finding {
   file: string | null;
   line: number | null;
   column: number | null;
+  /** Raw snippet or value that triggered this finding. */
   context?: string;
   suggestion: string;
   referenceUrl?: string;

--- a/tests/reporters/markdown.test.ts
+++ b/tests/reporters/markdown.test.ts
@@ -492,4 +492,266 @@ describe('renderMarkdown', () => {
       expect(md).toContain(emojis[i]);
     }
   });
+
+  // --- dataSource rendering (issue #104) ---
+
+  it('renders "(source: external API)" label when dataSource is "api"', () => {
+    const findings: Finding[] = [
+      {
+        id: 'sec-ds-01',
+        severity: Severity.CRITICAL,
+        pillar: Pillar.SECURITY,
+        category: 'permissions',
+        message: 'API-sourced finding',
+        file: null,
+        line: null,
+        column: null,
+        suggestion: 'Fix it',
+        dataSource: 'api',
+      },
+    ];
+    const md = renderMarkdown(makeReport(findings));
+    expect(md).toContain('(source: external API)');
+  });
+
+  it('renders "(source: local file check)" label when dataSource is "local"', () => {
+    const findings: Finding[] = [
+      {
+        id: 'sec-ds-02',
+        severity: Severity.CRITICAL,
+        pillar: Pillar.SECURITY,
+        category: 'permissions',
+        message: 'Local-sourced finding',
+        file: null,
+        line: null,
+        column: null,
+        suggestion: 'Fix it',
+        dataSource: 'local',
+      },
+    ];
+    const md = renderMarkdown(makeReport(findings));
+    expect(md).toContain('(source: local file check)');
+  });
+
+  it('renders "(source: computed heuristic)" label when dataSource is "heuristic"', () => {
+    const findings: Finding[] = [
+      {
+        id: 'sec-ds-03',
+        severity: Severity.CRITICAL,
+        pillar: Pillar.SECURITY,
+        category: 'permissions',
+        message: 'Heuristic-sourced finding',
+        file: null,
+        line: null,
+        column: null,
+        suggestion: 'Fix it',
+        dataSource: 'heuristic',
+      },
+    ];
+    const md = renderMarkdown(makeReport(findings));
+    expect(md).toContain('(source: computed heuristic)');
+  });
+
+  it('omits dataSource label when dataSource is not set on a critical finding', () => {
+    const findings: Finding[] = [
+      {
+        id: 'sec-ds-04',
+        severity: Severity.CRITICAL,
+        pillar: Pillar.SECURITY,
+        category: 'permissions',
+        message: 'Finding without dataSource',
+        file: null,
+        line: null,
+        column: null,
+        suggestion: 'Fix it',
+      },
+    ];
+    const md = renderMarkdown(makeReport(findings));
+    expect(md).not.toContain('(source:');
+  });
+
+  // --- context rendering (issue #104) ---
+
+  it('renders fenced code block with context value when context is set on a critical finding', () => {
+    const findings: Finding[] = [
+      {
+        id: 'sec-ctx-01',
+        severity: Severity.CRITICAL,
+        pillar: Pillar.SECURITY,
+        category: 'permissions',
+        message: 'Finding with context',
+        file: null,
+        line: null,
+        column: null,
+        suggestion: 'Fix it',
+        context: 'write-all: true',
+      },
+    ];
+    const md = renderMarkdown(makeReport(findings));
+    expect(md).toContain('**Context:**');
+    expect(md).toContain('```');
+    expect(md).toContain('write-all: true');
+  });
+
+  it('omits context block when context is not set on a critical finding', () => {
+    const findings: Finding[] = [
+      {
+        id: 'sec-ctx-02',
+        severity: Severity.CRITICAL,
+        pillar: Pillar.SECURITY,
+        category: 'permissions',
+        message: 'Finding without context',
+        file: null,
+        line: null,
+        column: null,
+        suggestion: 'Fix it',
+      },
+    ];
+    const md = renderMarkdown(makeReport(findings));
+    expect(md).not.toContain('**Context:**');
+  });
+
+  // --- metadata rendering (issue #104) ---
+
+  it('renders "Check: {name} — {score}/10" when checkName and checkScore are in metadata', () => {
+    const findings: Finding[] = [
+      {
+        id: 'sec-meta-01',
+        severity: Severity.CRITICAL,
+        pillar: Pillar.SECURITY,
+        category: 'permissions',
+        message: 'Finding with check metadata',
+        file: null,
+        line: null,
+        column: null,
+        suggestion: 'Fix it',
+        metadata: { checkName: 'Token-Permissions', checkScore: 3 },
+      },
+    ];
+    const md = renderMarkdown(makeReport(findings));
+    expect(md).toContain('Check: Token-Permissions — 3/10');
+  });
+
+  it('renders "Branch: {branch}" when branch is in metadata', () => {
+    const findings: Finding[] = [
+      {
+        id: 'sec-meta-02',
+        severity: Severity.CRITICAL,
+        pillar: Pillar.SECURITY,
+        category: 'permissions',
+        message: 'Finding with branch metadata',
+        file: null,
+        line: null,
+        column: null,
+        suggestion: 'Fix it',
+        metadata: { branch: 'main' },
+      },
+    ];
+    const md = renderMarkdown(makeReport(findings));
+    expect(md).toContain('Branch: main');
+  });
+
+  it('renders "Overall score: {score}" when overallScore is in metadata', () => {
+    const findings: Finding[] = [
+      {
+        id: 'sec-meta-03',
+        severity: Severity.CRITICAL,
+        pillar: Pillar.SECURITY,
+        category: 'permissions',
+        message: 'Finding with overallScore metadata',
+        file: null,
+        line: null,
+        column: null,
+        suggestion: 'Fix it',
+        metadata: { overallScore: 6.2 },
+      },
+    ];
+    const md = renderMarkdown(makeReport(findings));
+    expect(md).toContain('Overall score: 6.2');
+  });
+
+  it('renders Details block when at least one known metadata key is present', () => {
+    const findings: Finding[] = [
+      {
+        id: 'sec-meta-04',
+        severity: Severity.CRITICAL,
+        pillar: Pillar.SECURITY,
+        category: 'permissions',
+        message: 'Finding with metadata',
+        file: null,
+        line: null,
+        column: null,
+        suggestion: 'Fix it',
+        metadata: { branch: 'develop' },
+      },
+    ];
+    const md = renderMarkdown(makeReport(findings));
+    expect(md).toContain('**Details:**');
+  });
+
+  it('omits Details block when metadata is undefined', () => {
+    const findings: Finding[] = [
+      {
+        id: 'sec-meta-05',
+        severity: Severity.CRITICAL,
+        pillar: Pillar.SECURITY,
+        category: 'permissions',
+        message: 'Finding without metadata',
+        file: null,
+        line: null,
+        column: null,
+        suggestion: 'Fix it',
+      },
+    ];
+    const md = renderMarkdown(makeReport(findings));
+    expect(md).not.toContain('**Details:**');
+  });
+
+  it('omits Details block when metadata has no known keys', () => {
+    const findings: Finding[] = [
+      {
+        id: 'sec-meta-06',
+        severity: Severity.CRITICAL,
+        pillar: Pillar.SECURITY,
+        category: 'permissions',
+        message: 'Finding with unknown metadata only',
+        file: null,
+        line: null,
+        column: null,
+        suggestion: 'Fix it',
+        metadata: { unknownKey: 'value', anotherUnknown: 42 },
+      },
+    ];
+    const md = renderMarkdown(makeReport(findings));
+    expect(md).not.toContain('**Details:**');
+  });
+
+  it('renders all known metadata fields together when all are present', () => {
+    const findings: Finding[] = [
+      {
+        id: 'sec-meta-07',
+        severity: Severity.CRITICAL,
+        pillar: Pillar.SECURITY,
+        category: 'permissions',
+        message: 'Finding with full metadata',
+        file: null,
+        line: null,
+        column: null,
+        suggestion: 'Fix it',
+        dataSource: 'api',
+        context: 'permissions: write-all',
+        metadata: { checkName: 'Branch-Protection', checkScore: 5, branch: 'main', overallScore: 7.8 },
+      },
+    ];
+    const md = renderMarkdown(makeReport(findings));
+    expect(md).toContain('(source: external API)');
+    expect(md).toContain('**Context:**');
+    expect(md).toContain('permissions: write-all');
+    expect(md).toContain('**Details:**');
+    expect(md).toContain('Check: Branch-Protection — 5/10');
+    expect(md).toContain('Branch: main');
+    expect(md).toContain('Overall score: 7.8');
+    // suggestion must still be present
+    expect(md).toContain('**Suggestion:** Fix it');
+  });
 });


### PR DESCRIPTION
Closes #104

## Problem/Context

The markdown reporter silently drops `dataSource`, `context`, and `metadata` fields from `Finding` objects. Agents and humans reading the report lose provenance and detail that scanners capture.

## Solution

Add rendering for three optional `Finding` fields in the per-finding block of critical findings output (placed after message, before suggestion):

1. **`dataSource`** — small italic label: `_(source: external API)_` / `_(source: local file check)_` / `_(source: computed heuristic)_`
2. **`context`** — fenced code block under `**Context:**` heading
3. **`metadata`** — `**Details:**` block for known keys only: `checkName`+`checkScore`, `branch`, `overallScore`

Also adds `FindingDataSource = 'api' | 'local' | 'heuristic'` to `src/types/index.ts` and documents the existing `context` field.

All three fields guard against `undefined` — fully backward-compatible.

## Test Plan

TDD workflow: RED commit then GREEN commit.

New tests added (`tests/reporters/markdown.test.ts`):
- `dataSource: 'api'` → `(source: external API)` present
- `dataSource: 'local'` → `(source: local file check)` present
- `dataSource: 'heuristic'` → `(source: computed heuristic)` present
- No `dataSource` → no `(source:` text
- `context` set → `**Context:**` + fenced block present
- No `context` → no `**Context:**`
- `metadata.checkName + checkScore` → `Check: Name — N/10`
- `metadata.branch` → `Branch: name`
- `metadata.overallScore` → `Overall score: N`
- Known key present → `**Details:**` block shown
- No metadata → no `**Details:**`
- Unknown keys only → no `**Details:**`
- All fields together → all render correctly, `**Suggestion:**` still present

```
Test Files  77 passed (77)
     Tests  1405 passed (1405)
All files   97.55% statements | 92.49% branches | 99.75% functions
```

## Sample Output (finding with all fields set)

```markdown
### sec-sample-01
**Pillar:** Security | **Category:** permissions

API-sourced finding with full metadata

_(source: external API)_

**Context:**
```
permissions: write-all: true
```

**Details:**
Check: Token-Permissions — 3/10
Branch: main
Overall score: 6.2

> File: `.github/workflows/ci.yml`:12

**Suggestion:** Restrict token scope to read-only

**Reference:** https://docs.github.com/permissions
```

## Risk / Rollback

- Backward compatible: all new fields are optional, existing output unchanged when fields absent
- Rollback: revert two files (`src/types/index.ts`, `src/reporters/markdown.ts`)

## Story Type / Estimate

**Type:** Feature — **Points:** 2 (well-defined, contained to one reporter + type)