### PR TITLE
feat: add dataSource field to Finding interface

### DIFF
--- a/src/scanner/ai-readiness/agentic-rules.ts
+++ b/src/scanner/ai-readiness/agentic-rules.ts
@@ -92,6 +92,7 @@ export class AgenticRulesScanner implements Scanner {
       suggestion: agentCount > 0
         ? 'Agent configurations are in place for AI-assisted development.'
         : 'Consider adding CLAUDE.md, .cursorrules, or copilot-instructions.md to guide AI coding agents.',
+      dataSource: 'local',
       metadata: {
         agentCount,
         agentNames,
@@ -274,6 +275,7 @@ export class AgenticRulesScanner implements Scanner {
       suggestion: hasGoodStructure
         ? 'CLAUDE.md is well-structured for agent consumption.'
         : 'Add sections like "Critical Rules", "Project Structure", "Common Tasks" to improve agent guidance.',
+      dataSource: 'local',
       metadata: {
         source,
         sections: foundSections,

--- a/src/scanner/ai-readiness/ai-repo-detection.ts
+++ b/src/scanner/ai-readiness/ai-repo-detection.ts
@@ -224,6 +224,7 @@ export class AIRepoDetectionScanner implements Scanner {
       suggestion: detected
         ? 'Ensure model cards, dataset documentation, and agentic rules are in place.'
         : 'No action needed. AI-Readiness checks are informational for non-AI repositories.',
+      dataSource: 'local',
       metadata: {
         aiRepoDetected: detected,
         signals,

--- a/src/scanner/ai-readiness/dataset-provenance.ts
+++ b/src/scanner/ai-readiness/dataset-provenance.ts
@@ -162,6 +162,7 @@ export class DatasetProvenanceScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Create a DATASHEET.md documenting dataset motivation, composition, collection process, and intended uses.',
+        dataSource: 'local',
         metadata: { source: null, presentSections: [], missingSections: DATASHEET_SECTIONS.map((s) => s.name) },
       };
     }
@@ -195,6 +196,7 @@ export class DatasetProvenanceScanner implements Scanner {
           ? `Consider adding sections: ${missingSections.join(', ')}`
           : 'Datasheet is comprehensive.'
         : `Add missing sections to ${source}: ${missingSections.join(', ')}`,
+      dataSource: 'local',
       metadata: { source, presentSections, missingSections },
     };
   }
@@ -238,6 +240,7 @@ export class DatasetProvenanceScanner implements Scanner {
       file: null,
       line: null,
       column: null,
+      dataSource: 'local',
       suggestion: hasDVC
         ? 'DVC is properly configured for dataset versioning.'
         : 'Consider using DVC (Data Version Control) for dataset versioning and reproducibility.',

--- a/src/scanner/ai-readiness/model-card-detection.ts
+++ b/src/scanner/ai-readiness/model-card-detection.ts
@@ -112,6 +112,7 @@ export class ModelCardDetectionScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'No action needed for non-AI repositories.',
+        dataSource: 'local',
       }];
     }
 
@@ -174,6 +175,7 @@ export class ModelCardDetectionScanner implements Scanner {
           ? `Consider adding recommended sections: ${missingRecommended.join(', ')}`
           : 'Model card is comprehensive.'
         : `Add missing sections to ${source || 'README.md'}: ${missingRequired.join(', ')}`,
+      dataSource: 'local',
       metadata: {
         source,
         presentRequired,
@@ -240,6 +242,7 @@ export class ModelCardDetectionScanner implements Scanner {
       line: null,
       column: null,
       suggestion: 'Model index metadata is properly configured.',
+      dataSource: 'local',
       metadata: {
         hasModelIndex: true,
       },

--- a/src/scanner/ai-readiness/model-card-scoring.ts
+++ b/src/scanner/ai-readiness/model-card-scoring.ts
@@ -111,6 +111,7 @@ export class ModelCardScoringScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'No action needed for non-AI repositories.',
+        dataSource: 'local',
       }];
     }
 
@@ -161,6 +162,7 @@ export class ModelCardScoringScanner implements Scanner {
       suggestion: severity === Severity.PASS
         ? 'Model card is well-documented.'
         : `Improve model card in ${source || 'README.md'} by adding missing sections.`,
+      dataSource: 'local',
       metadata: {
         source,
         completenessPercent,

--- a/src/scanner/community/burnout-detection.ts
+++ b/src/scanner/community/burnout-detection.ts
@@ -66,6 +66,7 @@ export class BurnoutDetectionScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        dataSource: 'api',
         metadata,
       };
     };

--- a/src/scanner/community/contributor-data.ts
+++ b/src/scanner/community/contributor-data.ts
@@ -47,6 +47,7 @@ export class ContributorDataScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        dataSource: 'heuristic',
         metadata,
       };
     };

--- a/src/scanner/community/contributor-funnel.ts
+++ b/src/scanner/community/contributor-funnel.ts
@@ -50,6 +50,7 @@ export class ContributorFunnelScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        dataSource: 'heuristic',
         metadata,
       };
     };

--- a/src/scanner/community/funding.ts
+++ b/src/scanner/community/funding.ts
@@ -58,6 +58,7 @@ export class FundingScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        dataSource: 'local',
         metadata,
       };
     };

--- a/src/scanner/community/issue-closure.ts
+++ b/src/scanner/community/issue-closure.ts
@@ -57,6 +57,7 @@ export class IssueClosureScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        dataSource: 'api',
         metadata,
       };
     };

--- a/src/scanner/community/psych-safety.ts
+++ b/src/scanner/community/psych-safety.ts
@@ -54,6 +54,7 @@ export class PsychSafetyScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        dataSource: 'local',
         metadata,
       };
     };

--- a/src/scanner/community/response-classification.ts
+++ b/src/scanner/community/response-classification.ts
@@ -117,6 +117,7 @@ export class ResponseClassificationScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        dataSource: 'api',
         metadata,
       };
     };

--- a/src/scanner/community/response-time.ts
+++ b/src/scanner/community/response-time.ts
@@ -118,6 +118,7 @@ export class ResponseTimeScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        dataSource: 'api',
         metadata,
       };
     };

--- a/src/scanner/community/stale-bot.ts
+++ b/src/scanner/community/stale-bot.ts
@@ -91,6 +91,7 @@ export class StaleBotScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        dataSource: 'local',
         metadata,
       };
     };

--- a/src/scanner/community/support-channels.ts
+++ b/src/scanner/community/support-channels.ts
@@ -54,6 +54,7 @@ export class SupportChannelScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        dataSource: 'local',
         metadata,
       };
     };

--- a/src/scanner/governance/asset-protection.ts
+++ b/src/scanner/governance/asset-protection.ts
@@ -189,6 +189,7 @@ export class AssetProtectionScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Trademark policy is documented',
+        dataSource: 'local',
         metadata: { filePath: found },
       };
     }
@@ -203,6 +204,7 @@ export class AssetProtectionScanner implements Scanner {
       line: null,
       column: null,
       suggestion: 'Consider adding a TRADEMARK.md if the project has registered marks',
+      dataSource: 'local',
     };
   }
 
@@ -223,6 +225,7 @@ export class AssetProtectionScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Export control documentation is present',
+        dataSource: 'local',
         metadata: { filePath: found },
       };
     }
@@ -237,6 +240,7 @@ export class AssetProtectionScanner implements Scanner {
       line: null,
       column: null,
       suggestion: 'Consider adding an EXPORT-CONTROL.md if the project includes controlled technology',
+      dataSource: 'local',
     };
   }
 
@@ -267,6 +271,7 @@ export class AssetProtectionScanner implements Scanner {
             line: null,
             column: null,
             suggestion: 'CLA process is automated for contributors',
+            dataSource: 'local',
             metadata: {
               type: 'CLA',
               automated: true,
@@ -290,6 +295,7 @@ export class AssetProtectionScanner implements Scanner {
           line: null,
           column: null,
           suggestion: 'Add CLA automation (e.g., CLA Assistant bot) to reduce contributor friction',
+          dataSource: 'local',
           metadata: {
             type: 'CLA',
             automated: false,
@@ -318,6 +324,7 @@ export class AssetProtectionScanner implements Scanner {
           line: null,
           column: null,
           suggestion: 'DCO is a lightweight contributor agreement',
+          dataSource: 'local',
           metadata: {
             type: 'DCO',
             dcoFile: dcoFile || null,
@@ -341,6 +348,7 @@ export class AssetProtectionScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'No contributor agreement required - low barrier to contribution',
+        dataSource: 'local',
       },
       frictionLevel: 'Low',
     };
@@ -367,6 +375,7 @@ export class AssetProtectionScanner implements Scanner {
       line: null,
       column: null,
       suggestion: descriptions[frictionLevel],
+      dataSource: 'local',
       metadata: {
         frictionLevel,
       },

--- a/src/scanner/governance/bus-factor.ts
+++ b/src/scanner/governance/bus-factor.ts
@@ -124,6 +124,7 @@ export class BusFactorScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Ensure this is a git repository with commit history',
+        dataSource: 'heuristic',
       }];
     }
 
@@ -139,6 +140,7 @@ export class BusFactorScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Check if the repository has recent activity',
+        dataSource: 'heuristic',
       }];
     }
 
@@ -170,6 +172,7 @@ export class BusFactorScanner implements Scanner {
       suggestion: severity === Severity.PASS
         ? 'Contributor distribution is healthy'
         : 'Encourage more contributors and distribute code ownership',
+      dataSource: 'heuristic',
       metadata: {
         busFactor: analysis.busFactor,
         elephantFactor: analysis.elephantFactor,

--- a/src/scanner/governance/clearly-defined.ts
+++ b/src/scanner/governance/clearly-defined.ts
@@ -88,6 +88,7 @@ export class ClearlyDefinedScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        dataSource: 'api',
       };
     };
 

--- a/src/scanner/governance/dep-license-scanning.ts
+++ b/src/scanner/governance/dep-license-scanning.ts
@@ -60,6 +60,7 @@ export class DepLicenseScanningScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        dataSource: 'local',
         metadata,
       };
     };

--- a/src/scanner/governance/governance-classification.ts
+++ b/src/scanner/governance/governance-classification.ts
@@ -130,6 +130,7 @@ export class GovernanceClassificationScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        dataSource: 'local',
         metadata,
       };
     };

--- a/src/scanner/governance/governance-detection.ts
+++ b/src/scanner/governance/governance-detection.ts
@@ -51,6 +51,7 @@ export class GovernanceDetectionScanner implements Scanner {
           line: null,
           column: null,
           suggestion: 'Add governance documentation describing the decision-making process',
+          dataSource: 'local',
           metadata: { filePath: relativePath, content },
         }];
       }
@@ -66,6 +67,7 @@ export class GovernanceDetectionScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Governance documentation is present',
+        dataSource: 'local',
         metadata: { filePath: relativePath, content },
       }];
     }
@@ -81,6 +83,7 @@ export class GovernanceDetectionScanner implements Scanner {
       line: null,
       column: null,
       suggestion: 'Add a GOVERNANCE.md file describing the project decision-making process',
+      dataSource: 'local',
     }];
   }
 }

--- a/src/scanner/governance/license-compatibility.ts
+++ b/src/scanner/governance/license-compatibility.ts
@@ -81,6 +81,7 @@ export class LicenseCompatibilityScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        dataSource: 'local',
         metadata,
       };
     };

--- a/src/scanner/governance/license-content-validation.ts
+++ b/src/scanner/governance/license-content-validation.ts
@@ -176,6 +176,7 @@ export class LicenseContentValidationScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        dataSource: 'local',
         metadata,
       };
     };

--- a/src/scanner/governance/license-detection.ts
+++ b/src/scanner/governance/license-detection.ts
@@ -297,6 +297,7 @@ export class LicenseDetectionScanner implements Scanner {
       column: null,
       suggestion: 'License is properly declared.',
       referenceUrl: `https://spdx.org/licenses/${licenseId}.html`,
+      dataSource: 'local',
       metadata: {
         licenseId,
         confidence,
@@ -320,6 +321,7 @@ export class LicenseDetectionScanner implements Scanner {
       column: null,
       suggestion: 'Consider also adding a LICENSE file to the repository root for clarity.',
       referenceUrl: `https://spdx.org/licenses/${licenseId}.html`,
+      dataSource: 'local',
       metadata: {
         licenseId,
         confidence: 100,
@@ -343,6 +345,7 @@ export class LicenseDetectionScanner implements Scanner {
       column: null,
       suggestion: 'Add a LICENSE file to the repository root. Visit https://choosealicense.com/ for guidance.',
       referenceUrl: 'https://choosealicense.com/',
+      dataSource: 'local',
       metadata: {
         licenseId: 'NONE',
         confidence: 100,
@@ -366,6 +369,7 @@ export class LicenseDetectionScanner implements Scanner {
       column: null,
       suggestion: 'Use a well-known open source license. Visit https://choosealicense.com/ for guidance.',
       referenceUrl: 'https://choosealicense.com/',
+      dataSource: 'local',
       metadata: {
         licenseId: 'UNKNOWN',
         confidence: 0,

--- a/src/scanner/governance/license-headers.ts
+++ b/src/scanner/governance/license-headers.ts
@@ -308,6 +308,7 @@ export class LicenseHeaderScanner implements Scanner {
       line: 0,
       column: null,
       suggestion: 'This check applies to repositories containing source code files.',
+      dataSource: 'local',
       metadata: {
         filesScanned: 0,
         filesWithHeaders: 0,
@@ -332,6 +333,7 @@ export class LicenseHeaderScanner implements Scanner {
       column: null,
       suggestion:
         'Consider adding SPDX-License-Identifier headers to source files for clear per-file licensing. See https://spdx.dev/learn/handling-license-info/',
+      dataSource: 'local',
       metadata: {
         filesScanned,
         filesWithHeaders: 0,
@@ -360,6 +362,7 @@ export class LicenseHeaderScanner implements Scanner {
       column: null,
       suggestion: 'License headers are consistent with the project license.',
       referenceUrl: `https://spdx.org/licenses/${rootLicense}.html`,
+      dataSource: 'local',
       metadata: {
         matchCount,
         rootLicense,
@@ -382,6 +385,7 @@ export class LicenseHeaderScanner implements Scanner {
       column: null,
       suggestion: `Update the SPDX-License-Identifier in ${header.relativePath} to "${rootLicense}" or verify the intended license for this file.`,
       referenceUrl: 'https://spdx.dev/learn/handling-license-info/',
+      dataSource: 'local',
       metadata: {
         headerLicense: header.spdxId,
         rootLicense,
@@ -404,6 +408,7 @@ export class LicenseHeaderScanner implements Scanner {
       column: null,
       suggestion: 'Add a LICENSE file to the repository root so SPDX headers can be validated against the project license.',
       referenceUrl: 'https://choosealicense.com/',
+      dataSource: 'local',
     };
   }
 
@@ -429,6 +434,7 @@ export class LicenseHeaderScanner implements Scanner {
         filesWithHeaders < filesScanned
           ? 'Consider adding SPDX-License-Identifier headers to all source files.'
           : 'All scanned source files have SPDX license headers.',
+      dataSource: 'local',
       metadata: {
         filesScanned,
         filesWithHeaders,

--- a/src/scanner/governance/vendor-neutrality.ts
+++ b/src/scanner/governance/vendor-neutrality.ts
@@ -153,6 +153,7 @@ export class VendorNeutralityScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Ensure the repository has git history for vendor analysis',
+        dataSource: 'heuristic',
       });
       return findings;
     }
@@ -174,6 +175,7 @@ export class VendorNeutralityScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Vendor neutrality analysis requires commit history',
+        dataSource: 'heuristic',
       });
       return findings;
     }
@@ -195,6 +197,7 @@ export class VendorNeutralityScanner implements Scanner {
         column: null,
         suggestion: 'Diversify contributors across multiple organizations to reduce single-vendor risk',
         referenceUrl: 'https://chaoss.community/metric-organizational-diversity/',
+        dataSource: 'heuristic',
         metadata: {
           totalCommits: stats.totalCommits,
           uniqueDomains: stats.uniqueDomains,
@@ -213,6 +216,7 @@ export class VendorNeutralityScanner implements Scanner {
         column: null,
         suggestion: 'Encourage contributions from additional organizations to improve vendor diversity',
         referenceUrl: 'https://chaoss.community/metric-organizational-diversity/',
+        dataSource: 'heuristic',
         metadata: {
           totalCommits: stats.totalCommits,
           uniqueDomains: stats.uniqueDomains,
@@ -231,6 +235,7 @@ export class VendorNeutralityScanner implements Scanner {
         column: null,
         suggestion: 'Vendor diversity is healthy. Continue encouraging multi-organization contributions.',
         referenceUrl: 'https://chaoss.community/metric-organizational-diversity/',
+        dataSource: 'heuristic',
         metadata: {
           totalCommits: stats.totalCommits,
           uniqueDomains: stats.uniqueDomains,
@@ -250,6 +255,7 @@ export class VendorNeutralityScanner implements Scanner {
       line: null,
       column: null,
       suggestion: 'More unique domains indicates broader organizational participation',
+      dataSource: 'heuristic',
       metadata: {
         totalCommits: stats.totalCommits,
         uniqueDomains: stats.uniqueDomains,
@@ -270,6 +276,7 @@ export class VendorNeutralityScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Succession planning documentation is present',
+        dataSource: 'local',
         metadata: {
           successionPlanFound: true,
           successionFile: succession.file,
@@ -287,6 +294,7 @@ export class VendorNeutralityScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Add succession planning keywords (succession, bus factor, maintainer transition, emeritus) to GOVERNANCE.md or CONTRIBUTING.md',
+        dataSource: 'local',
       });
     }
 

--- a/src/scanner/inclusive/assumed-knowledge-scanner.ts
+++ b/src/scanner/inclusive/assumed-knowledge-scanner.ts
@@ -111,6 +111,7 @@ export class AssumedKnowledgeScanner implements Scanner {
             line: i + 1,
             column: null,
             suggestion: `Consider explaining what "${op.label}" means or linking to a beginner-friendly guide`,
+            dataSource: 'local',
           });
           break; // Only report one git operation per line
         }
@@ -150,6 +151,7 @@ export class AssumedKnowledgeScanner implements Scanner {
             line: i + 1,
             column: null,
             suggestion: `Add ${tool.prerequisite} to a Prerequisites section so newcomers know what to install`,
+            dataSource: 'local',
           });
           break; // Only report one tool per line
         }
@@ -217,6 +219,7 @@ export class AssumedKnowledgeScanner implements Scanner {
           line: i + 1,
           column: match.index + 1,
           suggestion: `Define "${acronym}" on first use, e.g., "${acronym} (Full Name)"`,
+          dataSource: 'local',
         });
       }
 
@@ -267,6 +270,7 @@ export class AssumedKnowledgeScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Consider adding a Prerequisites section listing required tools and versions',
+        dataSource: 'local',
       });
     }
 

--- a/src/scanner/inclusive/code-scanner.ts
+++ b/src/scanner/inclusive/code-scanner.ts
@@ -310,6 +310,7 @@ export class InclusiveCodeScanner implements Scanner {
                 column: region.startCol + 1,
                 context: line.trim(),
                 suggestion: `Consider using: ${term.replacements.join(', ')}`,
+                dataSource: 'local',
                 metadata: {
                   term: term.term,
                   tier: term.tier,

--- a/src/scanner/inclusive/diminishing-scanner.ts
+++ b/src/scanner/inclusive/diminishing-scanner.ts
@@ -211,6 +211,7 @@ export class DiminishingLanguageScanner implements Scanner {
               column: match.index + 1,
               context: line.trim(),
               suggestion: dp.suggestion,
+              dataSource: 'local',
             });
 
             fileMatchCount++;
@@ -252,6 +253,7 @@ export class DiminishingLanguageScanner implements Scanner {
       file: null,
       line: null,
       column: null,
+      dataSource: 'local',
       suggestion:
         welcomingScore > 85
           ? 'Documentation language is welcoming. Keep it up!'

--- a/src/scanner/inclusive/doc-scanner.ts
+++ b/src/scanner/inclusive/doc-scanner.ts
@@ -186,6 +186,7 @@ export class InclusiveDocScanner implements Scanner {
             context: contextSnippet,
             suggestion: `Replace "${matchedText}" with one of: ${term.replacements.join(', ')}`,
             referenceUrl: 'https://inclusivenaming.org/word-lists/',
+            dataSource: 'local',
             metadata: {
               matchedText,
               tier: term.tier,

--- a/src/scanner/inclusive/naming-scanner.ts
+++ b/src/scanner/inclusive/naming-scanner.ts
@@ -149,6 +149,7 @@ export class NamingScanner implements Scanner {
         column: null,
         suggestion: `Rename the project using an alternative term per the Inclusive Naming Initiative: ${term.replacements.join(', ')}`,
         referenceUrl: 'https://inclusivenaming.org/word-lists/',
+        dataSource: 'local',
         metadata: {
           term: term.term,
           tier: term.tier,
@@ -204,6 +205,7 @@ export class NamingScanner implements Scanner {
         column: null,
         suggestion: `Rename the project using an alternative term per the Inclusive Naming Initiative: ${term.replacements.join(', ')}`,
         referenceUrl: 'https://inclusivenaming.org/word-lists/',
+        dataSource: 'local',
         metadata: {
           term: term.term,
           tier: term.tier,
@@ -262,6 +264,7 @@ export class NamingScanner implements Scanner {
         column: null,
         suggestion: `Rename the project using an alternative term per the Inclusive Naming Initiative: ${term.replacements.join(', ')}`,
         referenceUrl: 'https://inclusivenaming.org/word-lists/',
+        dataSource: 'local',
         metadata: {
           term: term.term,
           tier: term.tier,

--- a/src/scanner/security/binary-artifacts.ts
+++ b/src/scanner/security/binary-artifacts.ts
@@ -121,6 +121,7 @@ export class BinaryArtifactScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Remove binary files from the source tree. Use a package manager or artifact repository instead.',
+        dataSource: 'local',
         metadata: {
           sha256,
           sizeBytes: stats.size,

--- a/src/scanner/security/branch-protection.ts
+++ b/src/scanner/security/branch-protection.ts
@@ -54,6 +54,7 @@ export class BranchProtectionScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        dataSource: 'api',
         metadata,
       };
     };

--- a/src/scanner/security/dep-pinning-docker.ts
+++ b/src/scanner/security/dep-pinning-docker.ts
@@ -42,6 +42,7 @@ export class DepPinningDockerScanner implements Scanner {
         line,
         column: null,
         suggestion,
+        dataSource: 'local',
       };
     };
 

--- a/src/scanner/security/dep-pinning-packages.ts
+++ b/src/scanner/security/dep-pinning-packages.ts
@@ -38,6 +38,7 @@ export class DepPinningPackagesScanner implements Scanner {
         line,
         column: null,
         suggestion,
+        dataSource: 'local',
       };
     };
 

--- a/src/scanner/security/openssf-local-checks.ts
+++ b/src/scanner/security/openssf-local-checks.ts
@@ -46,6 +46,7 @@ export class OpenSSFLocalChecksScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        dataSource: 'local',
         metadata: {
           scorecard_source: 'local',
           checkName,

--- a/src/scanner/security/openssf-scorecard.ts
+++ b/src/scanner/security/openssf-scorecard.ts
@@ -73,6 +73,7 @@ export class OpenSSFScorecardScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        dataSource: 'api',
         metadata,
       };
     };

--- a/src/scanner/security/token-permissions.ts
+++ b/src/scanner/security/token-permissions.ts
@@ -59,6 +59,7 @@ export class TokenPermissionsScanner implements Scanner {
         line,
         column: null,
         suggestion,
+        dataSource: 'local',
       };
     };
 

--- a/src/scanner/technical/interaction-templates.ts
+++ b/src/scanner/technical/interaction-templates.ts
@@ -79,6 +79,7 @@ export class InteractionTemplateScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        dataSource: 'local',
         metadata,
       };
     };

--- a/src/scanner/technical/linter-config.ts
+++ b/src/scanner/technical/linter-config.ts
@@ -104,6 +104,7 @@ export class LinterConfigScanner implements Scanner {
       line: null,
       column: null,
       suggestion,
+      dataSource: 'local',
     });
 
     // Check each linter's known config files

--- a/src/scanner/technical/release-cadence.ts
+++ b/src/scanner/technical/release-cadence.ts
@@ -62,6 +62,7 @@ export class ReleaseCadenceScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        dataSource: 'local',
         metadata,
       };
     };

--- a/src/scanner/technical/semver-validation.ts
+++ b/src/scanner/technical/semver-validation.ts
@@ -60,6 +60,7 @@ export class SemVerValidationScanner implements Scanner {
       line: null,
       column: null,
       suggestion,
+      dataSource: 'local',
       metadata,
     });
 

--- a/src/scanner/technical/test-coverage.ts
+++ b/src/scanner/technical/test-coverage.ts
@@ -165,6 +165,7 @@ export class TestCoverageScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        dataSource: 'local',
         metadata,
       };
     };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -81,6 +81,8 @@ export interface Scanner {
   run(context: ScanContext): Promise<Finding[]>;
 }
 
+export type FindingDataSource = 'api' | 'local' | 'heuristic';
+
 export interface Finding {
   id: string;
   severity: Severity;
@@ -93,6 +95,8 @@ export interface Finding {
   context?: string;
   suggestion: string;
   referenceUrl?: string;
+  /** Origin of the data used to produce this finding. */
+  dataSource?: FindingDataSource;
   metadata?: Record<string, unknown>;
 }
 

--- a/tests/scanner/datasource-field.test.ts
+++ b/tests/scanner/datasource-field.test.ts
@@ -510,20 +510,20 @@ describe('Inclusive scanner dataSource values', () => {
         fs.rmSync(tmpDir, { recursive: true, force: true });
     });
 
-    it('CodeScanner emits dataSource: local', async () => {
-        const { CodeScanner } = await import('../../src/scanner/inclusive/code-scanner.js');
-        const scanner = new CodeScanner();
+    it('InclusiveCodeScanner emits dataSource: local', async () => {
+        const { InclusiveCodeScanner } = await import('../../src/scanner/inclusive/code-scanner.js');
+        const scanner = new InclusiveCodeScanner();
         const ctx = makeContext(tmpDir);
-        // CodeScanner on empty dir may return []
+        // InclusiveCodeScanner on empty dir may return []
         const findings = await scanner.run(ctx);
         for (const f of findings) {
             expect(f.dataSource).toBe('local');
         }
     });
 
-    it('DocScanner emits dataSource: local', async () => {
-        const { DocScanner } = await import('../../src/scanner/inclusive/doc-scanner.js');
-        const scanner = new DocScanner();
+    it('InclusiveDocScanner emits dataSource: local', async () => {
+        const { InclusiveDocScanner } = await import('../../src/scanner/inclusive/doc-scanner.js');
+        const scanner = new InclusiveDocScanner();
         const ctx = makeContext(tmpDir);
         const findings = await scanner.run(ctx);
         for (const f of findings) {

--- a/tests/scanner/datasource-field.test.ts
+++ b/tests/scanner/datasource-field.test.ts
@@ -1,0 +1,582 @@
+/**
+ * Tests for the `dataSource` field on the Finding interface.
+ *
+ * Verifies that every scanner populates `dataSource` with one of:
+ *   'api' | 'local' | 'heuristic'
+ *
+ * Tests are organized by pillar. Representative scanners from each pillar
+ * are tested. Additional targeted tests verify the correct tier value.
+ *
+ * RED phase: these tests FAIL until `dataSource` is added to Finding
+ * and populated in every scanner.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+    Pillar,
+    Severity,
+    MaturityLevel,
+    ScanDepth,
+    OutputFormat,
+} from '../../src/types/index.js';
+import type { ScanContext, ScannerConfig, Finding } from '../../src/types/index.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const VALID_SOURCES = new Set(['api', 'local', 'heuristic']);
+
+function isValidDataSource(value: unknown): value is 'api' | 'local' | 'heuristic' {
+    return VALID_SOURCES.has(value as string);
+}
+
+function assertFindingsHaveDataSource(findings: Finding[], expectedSource: 'api' | 'local' | 'heuristic'): void {
+    expect(findings.length).toBeGreaterThan(0);
+    for (const finding of findings) {
+        expect(isValidDataSource(finding.dataSource)).toBe(true);
+        expect(finding.dataSource).toBe(expectedSource);
+    }
+}
+
+function baseConfig(): ScannerConfig {
+    return {
+        maturity: MaturityLevel.INCUBATING,
+        depth: ScanDepth.STANDARD,
+        format: OutputFormat.JSON,
+        output: null,
+        threshold: null,
+        quiet: false,
+        verbose: false,
+        scannerTimeout: 30_000,
+        githubToken: null,
+        zerodbApiKey: null,
+        zerodbProjectId: null,
+        ecosystem: false,
+        ecosystemDepth: 'static',
+        pillars: { disabled: [], weights: {}, disabledScanners: [] },
+        bots: { enabled: true, additional: [], exclude: [] },
+        inclusive: {
+            termListUrl: null,
+            customTerms: {},
+            ignoredTerms: [],
+            excludePatterns: [],
+        },
+    };
+}
+
+function makeContext(repoPath: string, overrides: Partial<ScanContext> = {}): ScanContext {
+    return {
+        repoPath,
+        repoIdentifier: null,
+        maturity: MaturityLevel.INCUBATING,
+        depth: ScanDepth.STANDARD,
+        config: baseConfig(),
+        git: { commitSha: null, branch: null, remoteUrl: null },
+        signal: AbortSignal.timeout(30_000),
+        emit: () => {},
+        ...overrides,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Type-level test: Finding interface must include dataSource
+// ---------------------------------------------------------------------------
+
+describe('Finding interface', () => {
+    it('accepts dataSource field with valid values', () => {
+        const finding: Finding = {
+            id: 'test-1',
+            severity: Severity.INFO,
+            pillar: Pillar.SECURITY,
+            category: 'test',
+            message: 'test message',
+            file: null,
+            line: null,
+            column: null,
+            suggestion: 'test suggestion',
+            dataSource: 'api',
+        };
+        expect(finding.dataSource).toBe('api');
+    });
+
+    it('accepts local as a dataSource', () => {
+        const finding: Finding = {
+            id: 'test-2',
+            severity: Severity.INFO,
+            pillar: Pillar.SECURITY,
+            category: 'test',
+            message: 'test message',
+            file: null,
+            line: null,
+            column: null,
+            suggestion: 'test suggestion',
+            dataSource: 'local',
+        };
+        expect(finding.dataSource).toBe('local');
+    });
+
+    it('accepts heuristic as a dataSource', () => {
+        const finding: Finding = {
+            id: 'test-3',
+            severity: Severity.INFO,
+            pillar: Pillar.SECURITY,
+            category: 'test',
+            message: 'test message',
+            file: null,
+            line: null,
+            column: null,
+            suggestion: 'test suggestion',
+            dataSource: 'heuristic',
+        };
+        expect(finding.dataSource).toBe('heuristic');
+    });
+
+    it('dataSource is optional — findings without it still type-check', () => {
+        const finding: Finding = {
+            id: 'test-4',
+            severity: Severity.INFO,
+            pillar: Pillar.SECURITY,
+            category: 'test',
+            message: 'test message',
+            file: null,
+            line: null,
+            column: null,
+            suggestion: 'test suggestion',
+        };
+        expect(finding.dataSource).toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Security scanners
+// ---------------------------------------------------------------------------
+
+describe('Security scanner dataSource values', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ds-test-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('OpenSSFScorecardScanner emits dataSource: api', async () => {
+        const { OpenSSFScorecardScanner } = await import('../../src/scanner/security/openssf-scorecard.js');
+        const scanner = new OpenSSFScorecardScanner();
+        const ctx = makeContext(tmpDir); // no remoteUrl → INFO finding
+        const findings = await scanner.run(ctx);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('api');
+        }
+    });
+
+    it('BranchProtectionScanner emits dataSource: api', async () => {
+        const { BranchProtectionScanner } = await import('../../src/scanner/security/branch-protection.js');
+        const scanner = new BranchProtectionScanner();
+        const ctx = makeContext(tmpDir); // no token → INFO finding
+        const findings = await scanner.run(ctx);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('api');
+        }
+    });
+
+    it('TokenPermissionsScanner emits dataSource: local', async () => {
+        const { TokenPermissionsScanner } = await import('../../src/scanner/security/token-permissions.js');
+        const scanner = new TokenPermissionsScanner();
+        // No .github/workflows dir → returns []
+        // Create a minimal workflow to get a finding
+        const workflowDir = path.join(tmpDir, '.github', 'workflows');
+        fs.mkdirSync(workflowDir, { recursive: true });
+        fs.writeFileSync(path.join(workflowDir, 'ci.yml'), 'on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n');
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        expect(findings.length).toBeGreaterThan(0);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('local');
+        }
+    });
+
+    it('DepPinningPackagesScanner emits dataSource: local', async () => {
+        const { DepPinningPackagesScanner } = await import('../../src/scanner/security/dep-pinning-packages.js');
+        const scanner = new DepPinningPackagesScanner();
+        // Create package.json with loosely pinned dep
+        fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({
+            dependencies: { 'lodash': '^4.17.21' },
+        }));
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        expect(findings.length).toBeGreaterThan(0);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('local');
+        }
+    });
+
+    it('BinaryArtifactScanner emits dataSource: local', async () => {
+        const { BinaryArtifactScanner } = await import('../../src/scanner/security/binary-artifacts.js');
+        const scanner = new BinaryArtifactScanner();
+        // Create a fake .exe file
+        fs.writeFileSync(path.join(tmpDir, 'app.exe'), Buffer.from([0x4d, 0x5a, 0x00, 0x00]));
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        expect(findings.length).toBeGreaterThan(0);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('local');
+        }
+    });
+
+    it('OpenSSFLocalChecksScanner emits dataSource: local', async () => {
+        const { OpenSSFLocalChecksScanner } = await import('../../src/scanner/security/openssf-local-checks.js');
+        const scanner = new OpenSSFLocalChecksScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        expect(findings.length).toBeGreaterThan(0);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('local');
+        }
+    });
+
+    it('DepPinningDockerScanner emits dataSource: local', async () => {
+        const { DepPinningDockerScanner } = await import('../../src/scanner/security/dep-pinning-docker.js');
+        const scanner = new DepPinningDockerScanner();
+        // Create a Dockerfile with latest tag
+        fs.writeFileSync(path.join(tmpDir, 'Dockerfile'), 'FROM node:latest\nRUN echo hi\n');
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        expect(findings.length).toBeGreaterThan(0);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('local');
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Governance scanners
+// ---------------------------------------------------------------------------
+
+describe('Governance scanner dataSource values', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ds-gov-test-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('LicenseDetectionScanner emits dataSource: local', async () => {
+        const { LicenseDetectionScanner } = await import('../../src/scanner/governance/license-detection.js');
+        const scanner = new LicenseDetectionScanner();
+        const ctx = makeContext(tmpDir); // no license file → CRITICAL finding
+        const findings = await scanner.run(ctx);
+        expect(findings.length).toBeGreaterThan(0);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('local');
+        }
+    });
+
+    it('BusFactorScanner emits dataSource: heuristic', async () => {
+        const { BusFactorScanner } = await import('../../src/scanner/governance/bus-factor.js');
+
+        // Mock execSync so we don't need a real git repo
+        vi.mock('node:child_process', () => ({
+            execSync: vi.fn().mockReturnValue('dev@example.com\ndev@example.com\nother@example.com\n'),
+        }));
+
+        const scanner = new BusFactorScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        expect(findings.length).toBeGreaterThan(0);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('heuristic');
+        }
+    });
+
+    it('ClearlyDefinedScanner emits dataSource: api', async () => {
+        const { ClearlyDefinedScanner } = await import('../../src/scanner/governance/clearly-defined.js');
+        // Mock fetch to return network error → INFO finding
+        const mockFetch = vi.fn().mockRejectedValue(new Error('network error'));
+        const scanner = new ClearlyDefinedScanner(mockFetch as unknown as typeof fetch);
+        // Need package.json with at least one dep
+        fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({
+            dependencies: { 'lodash': '4.17.21' },
+        }));
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        expect(findings.length).toBeGreaterThan(0);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('api');
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Community scanners
+// ---------------------------------------------------------------------------
+
+describe('Community scanner dataSource values', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ds-com-test-'));
+        vi.resetAllMocks();
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        vi.restoreAllMocks();
+    });
+
+    it('FundingScanner emits dataSource: local', async () => {
+        const { FundingScanner } = await import('../../src/scanner/community/funding.js');
+        const scanner = new FundingScanner();
+        const ctx = makeContext(tmpDir); // no .github/FUNDING.yml → finding about missing funding
+        const findings = await scanner.run(ctx);
+        expect(findings.length).toBeGreaterThan(0);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('local');
+        }
+    });
+
+    it('PsychSafetyScanner emits dataSource: local', async () => {
+        const { PsychSafetyScanner } = await import('../../src/scanner/community/psych-safety.js');
+        const scanner = new PsychSafetyScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        expect(findings.length).toBeGreaterThan(0);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('local');
+        }
+    });
+
+    it('StaleBotScanner emits dataSource: local', async () => {
+        const { StaleBotScanner } = await import('../../src/scanner/community/stale-bot.js');
+        const scanner = new StaleBotScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        expect(findings.length).toBeGreaterThan(0);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('local');
+        }
+    });
+
+    it('SupportChannelScanner emits dataSource: local', async () => {
+        const { SupportChannelScanner } = await import('../../src/scanner/community/support-channels.js');
+        const scanner = new SupportChannelScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        expect(findings.length).toBeGreaterThan(0);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('local');
+        }
+    });
+
+    it('BurnoutDetectionScanner emits dataSource: api when API call fails gracefully', async () => {
+        const { BurnoutDetectionScanner } = await import('../../src/scanner/community/burnout-detection.js');
+        const scanner = new BurnoutDetectionScanner();
+        const ctx = makeContext(tmpDir); // no remoteUrl → skipped/INFO
+        const findings = await scanner.run(ctx);
+        // When no remote URL, scanner may return [] or skip — just check populated ones
+        for (const f of findings) {
+            expect(f.dataSource).toBe('api');
+        }
+    });
+
+    it('IssueClosureScanner emits dataSource: api', async () => {
+        const { IssueClosureScanner } = await import('../../src/scanner/community/issue-closure.js');
+        const scanner = new IssueClosureScanner();
+        const ctx = makeContext(tmpDir); // no token/remoteUrl → early-exit or INFO
+        const findings = await scanner.run(ctx);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('api');
+        }
+    });
+
+    it('ResponseTimeScanner emits dataSource: api', async () => {
+        const { ResponseTimeScanner } = await import('../../src/scanner/community/response-time.js');
+        const scanner = new ResponseTimeScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('api');
+        }
+    });
+
+    it('ResponseClassificationScanner emits dataSource: api', async () => {
+        const { ResponseClassificationScanner } = await import('../../src/scanner/community/response-classification.js');
+        const scanner = new ResponseClassificationScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('api');
+        }
+    });
+
+    it('ContributorDataScanner emits dataSource: heuristic', async () => {
+        // Uses git log data but computes stats — heuristic
+        const { ContributorDataScanner } = await import('../../src/scanner/community/contributor-data.js');
+        vi.mock('node:child_process', () => ({
+            execSync: vi.fn().mockReturnValue('dev@example.com\ndev@example.com\n'),
+        }));
+        const scanner = new ContributorDataScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('heuristic');
+        }
+    });
+
+    it('ContributorFunnelScanner emits dataSource: heuristic', async () => {
+        const { ContributorFunnelScanner } = await import('../../src/scanner/community/contributor-funnel.js');
+        vi.mock('node:child_process', () => ({
+            execSync: vi.fn().mockReturnValue('dev@example.com\ndev@example.com\n'),
+        }));
+        const scanner = new ContributorFunnelScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('heuristic');
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// AI-readiness scanners
+// ---------------------------------------------------------------------------
+
+describe('AI-readiness scanner dataSource values', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ds-ai-test-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('AgenticRulesScanner emits dataSource: local', async () => {
+        const { AgenticRulesScanner } = await import('../../src/scanner/ai-readiness/agentic-rules.js');
+        const scanner = new AgenticRulesScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        expect(findings.length).toBeGreaterThan(0);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('local');
+        }
+    });
+
+    it('AIRepoDetectionScanner emits dataSource: local', async () => {
+        const { AIRepoDetectionScanner } = await import('../../src/scanner/ai-readiness/ai-repo-detection.js');
+        const scanner = new AIRepoDetectionScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        expect(findings.length).toBeGreaterThan(0);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('local');
+        }
+    });
+
+    it('ModelCardDetectionScanner emits dataSource: local', async () => {
+        const { ModelCardDetectionScanner } = await import('../../src/scanner/ai-readiness/model-card-detection.js');
+        const scanner = new ModelCardDetectionScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        expect(findings.length).toBeGreaterThan(0);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('local');
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Inclusive scanners
+// ---------------------------------------------------------------------------
+
+describe('Inclusive scanner dataSource values', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ds-inc-test-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('CodeScanner emits dataSource: local', async () => {
+        const { CodeScanner } = await import('../../src/scanner/inclusive/code-scanner.js');
+        const scanner = new CodeScanner();
+        const ctx = makeContext(tmpDir);
+        // CodeScanner on empty dir may return []
+        const findings = await scanner.run(ctx);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('local');
+        }
+    });
+
+    it('DocScanner emits dataSource: local', async () => {
+        const { DocScanner } = await import('../../src/scanner/inclusive/doc-scanner.js');
+        const scanner = new DocScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('local');
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Technical scanners
+// ---------------------------------------------------------------------------
+
+describe('Technical scanner dataSource values', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ds-tech-test-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('InteractionTemplateScanner emits dataSource: local', async () => {
+        const { InteractionTemplateScanner } = await import('../../src/scanner/technical/interaction-templates.js');
+        const scanner = new InteractionTemplateScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        expect(findings.length).toBeGreaterThan(0);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('local');
+        }
+    });
+
+    it('LinterConfigScanner emits dataSource: local', async () => {
+        const { LinterConfigScanner } = await import('../../src/scanner/technical/linter-config.js');
+        const scanner = new LinterConfigScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        expect(findings.length).toBeGreaterThan(0);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('local');
+        }
+    });
+
+    it('TestCoverageScanner emits dataSource: local', async () => {
+        const { TestCoverageScanner } = await import('../../src/scanner/technical/test-coverage.js');
+        const scanner = new TestCoverageScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        expect(findings.length).toBeGreaterThan(0);
+        for (const f of findings) {
+            expect(f.dataSource).toBe('local');
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- Adds `FindingDataSource = 'api' | 'local' | 'heuristic'` type to `src/types/index.ts`
- Adds optional `dataSource?: FindingDataSource` field to the `Finding` interface
- Populates `dataSource` in all 44 scanner implementations across all six pillars
- Adds 32 tests in `tests/scanner/datasource-field.test.ts` verifying correct tier per scanner

Tier mapping:
- `'api'` — findings sourced from external API calls (OpenSSF Scorecard, GitHub API branch-protection, ClearlyDefined, burnout/issue-closure/response scanners)
- `'local'` — findings from local file reading, regex, package.json parsing (all file-check scanners across security, governance, community, AI-readiness, inclusive, technical pillars)
- `'heuristic'` — findings computed from derived data (bus-factor, vendor-neutrality git analysis, contributor-data, contributor-funnel)

## Test plan

- [x] RED commit: 28 tests failing, 4 type-level tests passing — `d12b214`
- [x] GREEN commit: all 32 tests passing — `ec68ac9`
- [x] Run: `npm test -- --run tests/scanner/datasource-field.test.ts` → 32 passed
- [x] Pre-existing CLI integration failures (12 tests, `dist/cli.js` not built) confirmed pre-exist on base branch — not caused by this PR

Closes #103