### PR TITLE
feat: add Score Rationale section to markdown report

### DIFF
--- a/src/reporters/markdown.ts
+++ b/src/reporters/markdown.ts
@@ -1,4 +1,4 @@
-import { Severity, Pillar, RiskLevel } from '../types/index.js';
+import { Severity, Pillar, RiskLevel, PILLAR_WEIGHTS } from '../types/index.js';
 import type { ScanReport, Finding, FindingDataSource } from '../types/index.js';
 
 const PILLAR_LABELS: Record<Pillar, string> = {
@@ -183,6 +183,28 @@ export function renderMarkdown(report: ScanReport, options?: MarkdownReportOptio
     }
     lines.push('');
   }
+
+  // Score Rationale section
+  lines.push('## Score Rationale');
+  lines.push('');
+  lines.push('Overall score is a weighted sum of six pillar scores (each scored 0–10).');
+  lines.push('');
+  lines.push('| Pillar | Weight | Raw Score | Contribution |');
+  lines.push('|--------|--------|-----------|-------------|');
+
+  const pillarOrder = Object.keys(PILLAR_WEIGHTS) as Pillar[];
+  let totalWeight = 0;
+  for (const pillar of pillarOrder) {
+    const p = report.pillars[pillar];
+    const weight = PILLAR_WEIGHTS[pillar];
+    totalWeight += weight;
+    const weightPct = `${(weight * 100).toFixed(0)}%`;
+    const rawScore = p.score.toFixed(1);
+    const contribution = p.weightedScore.toFixed(2);
+    lines.push(`| ${PILLAR_LABELS[pillar]} | ${weightPct} | ${rawScore} | ${contribution} |`);
+  }
+  lines.push(`| **Overall** | **${(totalWeight * 100).toFixed(0)}%** | | **${report.overallScore.toFixed(2)}** |`);
+  lines.push('');
 
   // Metadata footer
   lines.push('---');

--- a/tests/reporters/markdown.test.ts
+++ b/tests/reporters/markdown.test.ts
@@ -841,8 +841,10 @@ describe('renderMarkdown', () => {
   it('renders Score Rationale section before the metadata footer', () => {
     const md = renderMarkdown(makeReport());
     const rationalePos = md.indexOf('## Score Rationale');
-    const footerPos = md.indexOf('---');
+    // The footer separator is a standalone "---" line (not a table alignment row)
+    const footerPos = md.indexOf('\n---\n');
     expect(rationalePos).toBeGreaterThan(0);
+    expect(footerPos).toBeGreaterThan(0);
     expect(rationalePos).toBeLessThan(footerPos);
   });
 

--- a/tests/reporters/markdown.test.ts
+++ b/tests/reporters/markdown.test.ts
@@ -754,4 +754,100 @@ describe('renderMarkdown', () => {
     // suggestion must still be present
     expect(md).toContain('**Suggestion:** Fix it');
   });
+
+  // --- Score Rationale section (issue #106) ---
+
+  it('renders "## Score Rationale" heading', () => {
+    const md = renderMarkdown(makeReport());
+    expect(md).toContain('## Score Rationale');
+  });
+
+  it('renders the intro sentence about weighted sum', () => {
+    const md = renderMarkdown(makeReport());
+    expect(md).toContain('Overall score is a weighted sum of six pillar scores');
+  });
+
+  it('renders all six pillar display names in the rationale table', () => {
+    const md = renderMarkdown(makeReport());
+    expect(md).toContain('Security');
+    expect(md).toContain('Governance');
+    expect(md).toContain('Community');
+    expect(md).toContain('AI Readiness');
+    expect(md).toContain('Inclusive Language');
+    expect(md).toContain('Technical Rigor');
+  });
+
+  it('renders pillar weights as percentages in the rationale table', () => {
+    const md = renderMarkdown(makeReport());
+    expect(md).toContain('25%');
+    expect(md).toContain('20%');
+    // Community, AI Readiness, and Inclusive all share 15%
+    expect(md).toContain('15%');
+    expect(md).toContain('10%');
+  });
+
+  it('renders correct raw score for each pillar (1 decimal place)', () => {
+    // makeReport() sets score = 7.5 for all pillars
+    const md = renderMarkdown(makeReport());
+    // There should be multiple occurrences of 7.5 (one per pillar in rationale)
+    const matches = md.match(/\|\s*7\.5\s*\|/g);
+    expect(matches).not.toBeNull();
+    expect(matches!.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('renders correct contribution (weightedScore) for each pillar (2 decimal places)', () => {
+    // weightedScore for Security pillar: 7.5 * 0.25 = 1.875 → rounds to 1.88
+    const md = renderMarkdown(makeReport());
+    expect(md).toContain('1.88');
+    // Governance: 7.5 * 0.20 = 1.5 → 1.50
+    expect(md).toContain('1.50');
+    // Community: 7.5 * 0.15 = 1.125 → 1.13 (or 1.12 depending on rounding)
+    // AI Readiness: 7.5 * 0.15 = 1.125
+    // Inclusive: 7.5 * 0.15 = 1.125
+    // Technical: 7.5 * 0.10 = 0.75 → 0.75
+    expect(md).toContain('0.75');
+  });
+
+  it('renders a bold Overall row with the final score', () => {
+    const md = renderMarkdown(makeReport());
+    // The overall row should be bold and contain 100%
+    expect(md).toContain('**Overall**');
+    expect(md).toContain('**100%**');
+  });
+
+  it('renders the overall score in the Overall row to 2 decimal places', () => {
+    // makeReport() sets overallScore = 7.5 → "7.50"
+    const md = renderMarkdown(makeReport());
+    expect(md).toContain('**7.50**');
+  });
+
+  it('renders Score Rationale section after the recommendations section', () => {
+    const recs: Recommendation[] = [
+      {
+        priority: 1,
+        action: 'Add branch protection',
+        impact: 'high',
+        effort: 'low',
+        findingIds: [],
+        resources: [],
+      },
+    ];
+    const md = renderMarkdown(makeReport([], recs));
+    const rationale_pos = md.indexOf('## Score Rationale');
+    const recommendations_pos = md.indexOf('## Recommendations');
+    expect(rationale_pos).toBeGreaterThan(recommendations_pos);
+  });
+
+  it('renders Score Rationale section before the metadata footer', () => {
+    const md = renderMarkdown(makeReport());
+    const rationalePos = md.indexOf('## Score Rationale');
+    const footerPos = md.indexOf('---');
+    expect(rationalePos).toBeGreaterThan(0);
+    expect(rationalePos).toBeLessThan(footerPos);
+  });
+
+  it('renders the rationale table header row with correct columns', () => {
+    const md = renderMarkdown(makeReport());
+    expect(md).toContain('| Pillar | Weight | Raw Score | Contribution |');
+  });
 });


### PR DESCRIPTION
Closes #106

## Problem/Context

The markdown report showed pillar scores in the Pillar Scores table but gave no explanation of how the overall score was derived from those pillars. Readers had no visibility into the weight formula.

## Solution

Added a `## Score Rationale` section after the Recommendations section and before the metadata footer. The section renders:

- A one-sentence explanation of the weighted-sum formula
- A table with columns: Pillar | Weight | Raw Score | Contribution
- One row per pillar (Security → Governance → Community → AI Readiness → Inclusive Language → Technical Rigor)
- A bold **Overall** summary row showing 100% weight and the final score to 2 decimal places

Human-readable display names (e.g. "Inclusive Language", "Technical Rigor") are used instead of enum values. Weight is rendered as a percentage (e.g. 25%). Raw score is rounded to 1 dp; contribution to 2 dp.

## Test Plan

8 new tests added to `tests/reporters/markdown.test.ts`:

- `## Score Rationale` heading present
- Intro sentence present
- All six pillar display names present
- Weight percentages (25%, 20%, 15%, 10%) present
- Raw score and contribution values correct
- Bold Overall row with `**100%**` and `**7.50**`
- Section appears after Recommendations
- Section appears before footer `---` line
- Table header row has correct columns

```
Tests  1448 passed (1448)
All files | 97.57% statements | 92.57% branches | 99.75% functions | 97.57% lines
```

## Sample Output

```markdown
## Score Rationale

Overall score is a weighted sum of six pillar scores (each scored 0–10).

| Pillar | Weight | Raw Score | Contribution |
|--------|--------|-----------|-------------|
| Security | 25% | 8.2 | 2.05 |
| Governance | 20% | 7.5 | 1.50 |
| Community | 15% | 6.0 | 0.90 |
| AI Readiness | 15% | 9.0 | 1.35 |
| Inclusive Language | 15% | 5.0 | 0.75 |
| Technical Rigor | 10% | 8.5 | 0.85 |
| **Overall** | **100%** | | **7.40** |
```

## Risk / Rollback

Additive only — no existing output is modified, only appended before the footer. Rolling back is a single revert of `src/reporters/markdown.ts`.

## Story type & estimate

**Type:** Feature — **Points:** 1 (clear, contained addition)