### PR TITLE
feat: populate referenceUrl in all 43 scanners

### DIFF
--- a/src/scanner/ai-readiness/agentic-rules.ts
+++ b/src/scanner/ai-readiness/agentic-rules.ts
@@ -92,6 +92,7 @@ export class AgenticRulesScanner implements Scanner {
       suggestion: agentCount > 0
         ? 'Agent configurations are in place for AI-assisted development.'
         : 'Consider adding CLAUDE.md, .cursorrules, or copilot-instructions.md to guide AI coding agents.',
+      referenceUrl: 'https://chaoss.community/metric-ai-readiness/',
       dataSource: 'local',
       metadata: {
         agentCount,
@@ -275,6 +276,7 @@ export class AgenticRulesScanner implements Scanner {
       suggestion: hasGoodStructure
         ? 'CLAUDE.md is well-structured for agent consumption.'
         : 'Add sections like "Critical Rules", "Project Structure", "Common Tasks" to improve agent guidance.',
+      referenceUrl: 'https://chaoss.community/metric-ai-readiness/',
       dataSource: 'local',
       metadata: {
         source,

--- a/src/scanner/ai-readiness/ai-repo-detection.ts
+++ b/src/scanner/ai-readiness/ai-repo-detection.ts
@@ -224,6 +224,7 @@ export class AIRepoDetectionScanner implements Scanner {
       suggestion: detected
         ? 'Ensure model cards, dataset documentation, and agentic rules are in place.'
         : 'No action needed. AI-Readiness checks are informational for non-AI repositories.',
+      referenceUrl: 'https://chaoss.community/metric-ai-readiness/',
       dataSource: 'local',
       metadata: {
         aiRepoDetected: detected,

--- a/src/scanner/ai-readiness/dataset-provenance.ts
+++ b/src/scanner/ai-readiness/dataset-provenance.ts
@@ -68,6 +68,7 @@ export class DatasetProvenanceScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'No action needed for non-AI repositories.',
+        referenceUrl: 'https://huggingface.co/docs/hub/en/datasets-cards',
       }];
     }
 
@@ -93,6 +94,7 @@ export class DatasetProvenanceScanner implements Scanner {
       suggestion: datasetsDetected
         ? 'Ensure dataset documentation is provided.'
         : 'No action needed.',
+      referenceUrl: 'https://huggingface.co/docs/hub/en/datasets-cards',
       metadata: {
         datasetsDetected,
         datasetSignals,
@@ -162,6 +164,7 @@ export class DatasetProvenanceScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Create a DATASHEET.md documenting dataset motivation, composition, collection process, and intended uses.',
+        referenceUrl: 'https://huggingface.co/docs/hub/en/datasets-cards',
         dataSource: 'local',
         metadata: { source: null, presentSections: [], missingSections: DATASHEET_SECTIONS.map((s) => s.name) },
       };
@@ -196,6 +199,7 @@ export class DatasetProvenanceScanner implements Scanner {
           ? `Consider adding sections: ${missingSections.join(', ')}`
           : 'Datasheet is comprehensive.'
         : `Add missing sections to ${source}: ${missingSections.join(', ')}`,
+      referenceUrl: 'https://huggingface.co/docs/hub/en/datasets-cards',
       dataSource: 'local',
       metadata: { source, presentSections, missingSections },
     };
@@ -244,6 +248,7 @@ export class DatasetProvenanceScanner implements Scanner {
       suggestion: hasDVC
         ? 'DVC is properly configured for dataset versioning.'
         : 'Consider using DVC (Data Version Control) for dataset versioning and reproducibility.',
+      referenceUrl: 'https://huggingface.co/docs/hub/en/datasets-cards',
       metadata: { hasDVC, dvcSignals },
     };
   }

--- a/src/scanner/ai-readiness/model-card-detection.ts
+++ b/src/scanner/ai-readiness/model-card-detection.ts
@@ -112,6 +112,7 @@ export class ModelCardDetectionScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'No action needed for non-AI repositories.',
+        referenceUrl: 'https://huggingface.co/docs/hub/en/model-cards',
         dataSource: 'local',
       }];
     }
@@ -175,6 +176,7 @@ export class ModelCardDetectionScanner implements Scanner {
           ? `Consider adding recommended sections: ${missingRecommended.join(', ')}`
           : 'Model card is comprehensive.'
         : `Add missing sections to ${source || 'README.md'}: ${missingRequired.join(', ')}`,
+      referenceUrl: 'https://huggingface.co/docs/hub/en/model-cards',
       dataSource: 'local',
       metadata: {
         source,
@@ -242,6 +244,7 @@ export class ModelCardDetectionScanner implements Scanner {
       line: null,
       column: null,
       suggestion: 'Model index metadata is properly configured.',
+      referenceUrl: 'https://huggingface.co/docs/hub/en/model-cards',
       dataSource: 'local',
       metadata: {
         hasModelIndex: true,

--- a/src/scanner/ai-readiness/model-card-scoring.ts
+++ b/src/scanner/ai-readiness/model-card-scoring.ts
@@ -111,6 +111,7 @@ export class ModelCardScoringScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'No action needed for non-AI repositories.',
+        referenceUrl: 'https://huggingface.co/docs/hub/en/model-cards',
         dataSource: 'local',
       }];
     }
@@ -162,6 +163,7 @@ export class ModelCardScoringScanner implements Scanner {
       suggestion: severity === Severity.PASS
         ? 'Model card is well-documented.'
         : `Improve model card in ${source || 'README.md'} by adding missing sections.`,
+      referenceUrl: 'https://huggingface.co/docs/hub/en/model-cards',
       dataSource: 'local',
       metadata: {
         source,

--- a/src/scanner/community/burnout-detection.ts
+++ b/src/scanner/community/burnout-detection.ts
@@ -66,6 +66,7 @@ export class BurnoutDetectionScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        referenceUrl: 'https://chaoss.community/metric-project-burnout/',
         dataSource: 'api',
         metadata,
       };

--- a/src/scanner/community/contributor-data.ts
+++ b/src/scanner/community/contributor-data.ts
@@ -47,6 +47,7 @@ export class ContributorDataScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        referenceUrl: 'https://chaoss.community/metric-contributors/',
         dataSource: 'heuristic',
         metadata,
       };

--- a/src/scanner/community/contributor-funnel.ts
+++ b/src/scanner/community/contributor-funnel.ts
@@ -50,6 +50,7 @@ export class ContributorFunnelScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        referenceUrl: 'https://chaoss.community/metric-contributor-activity/',
         dataSource: 'heuristic',
         metadata,
       };

--- a/src/scanner/community/funding.ts
+++ b/src/scanner/community/funding.ts
@@ -58,6 +58,7 @@ export class FundingScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        referenceUrl: 'https://chaoss.community/metric-project-funding/',
         dataSource: 'local',
         metadata,
       };

--- a/src/scanner/community/issue-closure.ts
+++ b/src/scanner/community/issue-closure.ts
@@ -57,6 +57,7 @@ export class IssueClosureScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        referenceUrl: 'https://chaoss.community/metric-issue-resolution-duration/',
         dataSource: 'api',
         metadata,
       };

--- a/src/scanner/community/psych-safety.ts
+++ b/src/scanner/community/psych-safety.ts
@@ -54,6 +54,7 @@ export class PsychSafetyScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        referenceUrl: 'https://chaoss.community/metric-psychological-safety/',
         dataSource: 'local',
         metadata,
       };

--- a/src/scanner/community/response-classification.ts
+++ b/src/scanner/community/response-classification.ts
@@ -117,6 +117,7 @@ export class ResponseClassificationScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        referenceUrl: 'https://chaoss.community/metric-issue-response-time/',
         dataSource: 'api',
         metadata,
       };

--- a/src/scanner/community/response-time.ts
+++ b/src/scanner/community/response-time.ts
@@ -118,6 +118,7 @@ export class ResponseTimeScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        referenceUrl: 'https://chaoss.community/metric-issue-response-time/',
         dataSource: 'api',
         metadata,
       };

--- a/src/scanner/community/stale-bot.ts
+++ b/src/scanner/community/stale-bot.ts
@@ -91,6 +91,7 @@ export class StaleBotScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        referenceUrl: 'https://chaoss.community/metric-issue-age/',
         dataSource: 'local',
         metadata,
       };

--- a/src/scanner/community/support-channels.ts
+++ b/src/scanner/community/support-channels.ts
@@ -54,6 +54,7 @@ export class SupportChannelScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        referenceUrl: 'https://chaoss.community/metric-chat-platform-activity/',
         dataSource: 'local',
         metadata,
       };

--- a/src/scanner/governance/asset-protection.ts
+++ b/src/scanner/governance/asset-protection.ts
@@ -189,7 +189,8 @@ export class AssetProtectionScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Trademark policy is documented',
-        dataSource: 'local',
+        referenceUrl: 'https://github.com/ossf/scorecard/blob/main/docs/checks.md',
+      dataSource: 'local',
         metadata: { filePath: found },
       };
     }
@@ -204,6 +205,7 @@ export class AssetProtectionScanner implements Scanner {
       line: null,
       column: null,
       suggestion: 'Consider adding a TRADEMARK.md if the project has registered marks',
+      referenceUrl: 'https://github.com/ossf/scorecard/blob/main/docs/checks.md',
       dataSource: 'local',
     };
   }
@@ -225,7 +227,8 @@ export class AssetProtectionScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Export control documentation is present',
-        dataSource: 'local',
+        referenceUrl: 'https://github.com/ossf/scorecard/blob/main/docs/checks.md',
+      dataSource: 'local',
         metadata: { filePath: found },
       };
     }
@@ -240,6 +243,7 @@ export class AssetProtectionScanner implements Scanner {
       line: null,
       column: null,
       suggestion: 'Consider adding an EXPORT-CONTROL.md if the project includes controlled technology',
+      referenceUrl: 'https://github.com/ossf/scorecard/blob/main/docs/checks.md',
       dataSource: 'local',
     };
   }
@@ -271,7 +275,8 @@ export class AssetProtectionScanner implements Scanner {
             line: null,
             column: null,
             suggestion: 'CLA process is automated for contributors',
-            dataSource: 'local',
+            referenceUrl: 'https://github.com/ossf/scorecard/blob/main/docs/checks.md',
+      dataSource: 'local',
             metadata: {
               type: 'CLA',
               automated: true,
@@ -295,7 +300,8 @@ export class AssetProtectionScanner implements Scanner {
           line: null,
           column: null,
           suggestion: 'Add CLA automation (e.g., CLA Assistant bot) to reduce contributor friction',
-          dataSource: 'local',
+          referenceUrl: 'https://github.com/ossf/scorecard/blob/main/docs/checks.md',
+      dataSource: 'local',
           metadata: {
             type: 'CLA',
             automated: false,
@@ -324,7 +330,8 @@ export class AssetProtectionScanner implements Scanner {
           line: null,
           column: null,
           suggestion: 'DCO is a lightweight contributor agreement',
-          dataSource: 'local',
+          referenceUrl: 'https://github.com/ossf/scorecard/blob/main/docs/checks.md',
+      dataSource: 'local',
           metadata: {
             type: 'DCO',
             dcoFile: dcoFile || null,
@@ -348,7 +355,8 @@ export class AssetProtectionScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'No contributor agreement required - low barrier to contribution',
-        dataSource: 'local',
+        referenceUrl: 'https://github.com/ossf/scorecard/blob/main/docs/checks.md',
+      dataSource: 'local',
       },
       frictionLevel: 'Low',
     };
@@ -375,6 +383,7 @@ export class AssetProtectionScanner implements Scanner {
       line: null,
       column: null,
       suggestion: descriptions[frictionLevel],
+      referenceUrl: 'https://github.com/ossf/scorecard/blob/main/docs/checks.md',
       dataSource: 'local',
       metadata: {
         frictionLevel,

--- a/src/scanner/governance/bus-factor.ts
+++ b/src/scanner/governance/bus-factor.ts
@@ -124,6 +124,7 @@ export class BusFactorScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Ensure this is a git repository with commit history',
+        referenceUrl: 'https://chaoss.community/metric-bus-factor/',
         dataSource: 'heuristic',
       }];
     }
@@ -140,6 +141,7 @@ export class BusFactorScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Check if the repository has recent activity',
+        referenceUrl: 'https://chaoss.community/metric-bus-factor/',
         dataSource: 'heuristic',
       }];
     }
@@ -172,6 +174,7 @@ export class BusFactorScanner implements Scanner {
       suggestion: severity === Severity.PASS
         ? 'Contributor distribution is healthy'
         : 'Encourage more contributors and distribute code ownership',
+      referenceUrl: 'https://chaoss.community/metric-bus-factor/',
       dataSource: 'heuristic',
       metadata: {
         busFactor: analysis.busFactor,

--- a/src/scanner/governance/clearly-defined.ts
+++ b/src/scanner/governance/clearly-defined.ts
@@ -71,11 +71,14 @@ export class ClearlyDefinedScanner implements Scanner {
     const { repoPath } = context;
     let counter = 0;
 
+    const CLEARLYDEFINED_FALLBACK = 'https://clearlydefined.io/';
+
     const makeFinding = (
       severity: Severity,
       message: string,
       file: string | null,
       suggestion: string,
+      referenceUrl: string = CLEARLYDEFINED_FALLBACK,
     ): Finding => {
       counter++;
       return {
@@ -88,6 +91,7 @@ export class ClearlyDefinedScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        referenceUrl,
         dataSource: 'api',
       };
     };
@@ -119,6 +123,10 @@ export class ClearlyDefinedScanner implements Scanner {
       // Resolve the concrete version.
       const version = this.resolveVersion(repoPath, name, versionSpec);
 
+      // Computed Tier A referenceUrl for this specific package+version
+      const depReferenceUrl =
+        `https://clearlydefined.io/definitions/npm/npmjs/-/${name}/${version}`;
+
       // Query ClearlyDefined.
       let declaredLicense: string | null | undefined;
       try {
@@ -133,6 +141,7 @@ export class ClearlyDefinedScanner implements Scanner {
               'ClearlyDefined API unavailable — cross-validation skipped',
               null,
               'Check network connectivity or try again later',
+              CLEARLYDEFINED_FALLBACK,
             ),
           ];
         }
@@ -146,12 +155,13 @@ export class ClearlyDefinedScanner implements Scanner {
             'ClearlyDefined API unavailable — cross-validation skipped',
             null,
             'Check network connectivity or try again later',
+            CLEARLYDEFINED_FALLBACK,
           ),
         ];
       }
 
       // Evaluate the declared license.
-      const finding = this.evaluateLicense(name, version, declaredLicense ?? null, makeFinding);
+      const finding = this.evaluateLicense(name, version, declaredLicense ?? null, makeFinding, depReferenceUrl);
       if (finding !== null) {
         findings.push(finding);
       }
@@ -205,7 +215,9 @@ export class ClearlyDefinedScanner implements Scanner {
       message: string,
       file: string | null,
       suggestion: string,
+      referenceUrl?: string,
     ) => Finding,
+    referenceUrl: string,
   ): Finding | null {
     // No license data.
     if (declared === null || declared === undefined || declared === 'NOASSERTION') {
@@ -214,6 +226,7 @@ export class ClearlyDefinedScanner implements Scanner {
         `ClearlyDefined has no license data for ${name}@${version}`,
         'package.json',
         'Check the package manually and consider opening a curation PR at clearlydefined.io',
+        referenceUrl,
       );
     }
 
@@ -224,6 +237,7 @@ export class ClearlyDefinedScanner implements Scanner {
         `ClearlyDefined confirms ${name}@${version} is licensed ${declared} (copyleft)`,
         'package.json',
         "Evaluate whether this copyleft license is compatible with your project's licensing obligations",
+        referenceUrl,
       );
     }
 
@@ -238,6 +252,7 @@ export class ClearlyDefinedScanner implements Scanner {
       `ClearlyDefined reports an uncommon license for ${name}@${version}: ${declared}`,
       'package.json',
       'Review the license terms manually',
+      referenceUrl,
     );
   }
 

--- a/src/scanner/governance/dep-license-scanning.ts
+++ b/src/scanner/governance/dep-license-scanning.ts
@@ -60,6 +60,7 @@ export class DepLicenseScanningScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        referenceUrl: 'https://spdx.org/licenses/',
         dataSource: 'local',
         metadata,
       };

--- a/src/scanner/governance/governance-classification.ts
+++ b/src/scanner/governance/governance-classification.ts
@@ -127,6 +127,7 @@ export class GovernanceClassificationScanner implements Scanner {
         category: 'governance',
         message,
         file,
+        referenceUrl: 'https://chaoss.community/metric-project-licenses/',
         line: null,
         column: null,
         suggestion,

--- a/src/scanner/governance/governance-detection.ts
+++ b/src/scanner/governance/governance-detection.ts
@@ -51,6 +51,7 @@ export class GovernanceDetectionScanner implements Scanner {
           line: null,
           column: null,
           suggestion: 'Add governance documentation describing the decision-making process',
+          referenceUrl: 'https://opensource.guide/leadership-and-governance/',
           dataSource: 'local',
           metadata: { filePath: relativePath, content },
         }];
@@ -67,6 +68,7 @@ export class GovernanceDetectionScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Governance documentation is present',
+        referenceUrl: 'https://opensource.guide/leadership-and-governance/',
         dataSource: 'local',
         metadata: { filePath: relativePath, content },
       }];
@@ -83,6 +85,7 @@ export class GovernanceDetectionScanner implements Scanner {
       line: null,
       column: null,
       suggestion: 'Add a GOVERNANCE.md file describing the project decision-making process',
+      referenceUrl: 'https://opensource.guide/leadership-and-governance/',
       dataSource: 'local',
     }];
   }

--- a/src/scanner/governance/license-compatibility.ts
+++ b/src/scanner/governance/license-compatibility.ts
@@ -81,6 +81,7 @@ export class LicenseCompatibilityScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        referenceUrl: 'https://spdx.org/licenses/',
         dataSource: 'local',
         metadata,
       };

--- a/src/scanner/governance/license-content-validation.ts
+++ b/src/scanner/governance/license-content-validation.ts
@@ -158,12 +158,15 @@ export class LicenseContentValidationScanner implements Scanner {
     const { repoPath } = context;
     let counter = 0;
 
+    const SPDX_FALLBACK = 'https://spdx.org/licenses/';
+
     const makeFinding = (
       severity: Severity,
       message: string,
       file: string | null,
       suggestion: string,
       metadata?: Record<string, unknown>,
+      referenceUrl: string = SPDX_FALLBACK,
     ): Finding => {
       counter++;
       return {
@@ -176,6 +179,7 @@ export class LicenseContentValidationScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        referenceUrl,
         dataSource: 'local',
         metadata,
       };
@@ -249,6 +253,7 @@ export class LicenseContentValidationScanner implements Scanner {
             licenseName: match.name,
             matchRatio: Math.round(matchRatio * 100),
           },
+          `https://spdx.org/licenses/${match.id}.html`,
         ),
       ];
     }
@@ -264,6 +269,7 @@ export class LicenseContentValidationScanner implements Scanner {
           licenseName: match.name,
           matchRatio: Math.round(matchRatio * 100),
         },
+        `https://spdx.org/licenses/${match.id}.html`,
       ),
     ];
   }

--- a/src/scanner/governance/license-headers.ts
+++ b/src/scanner/governance/license-headers.ts
@@ -308,6 +308,7 @@ export class LicenseHeaderScanner implements Scanner {
       line: 0,
       column: null,
       suggestion: 'This check applies to repositories containing source code files.',
+      referenceUrl: 'https://reuse.software/spec/',
       dataSource: 'local',
       metadata: {
         filesScanned: 0,
@@ -333,6 +334,7 @@ export class LicenseHeaderScanner implements Scanner {
       column: null,
       suggestion:
         'Consider adding SPDX-License-Identifier headers to source files for clear per-file licensing. See https://spdx.dev/learn/handling-license-info/',
+      referenceUrl: 'https://reuse.software/spec/',
       dataSource: 'local',
       metadata: {
         filesScanned,
@@ -434,6 +436,7 @@ export class LicenseHeaderScanner implements Scanner {
         filesWithHeaders < filesScanned
           ? 'Consider adding SPDX-License-Identifier headers to all source files.'
           : 'All scanned source files have SPDX license headers.',
+      referenceUrl: 'https://reuse.software/spec/',
       dataSource: 'local',
       metadata: {
         filesScanned,

--- a/src/scanner/governance/vendor-neutrality.ts
+++ b/src/scanner/governance/vendor-neutrality.ts
@@ -153,6 +153,7 @@ export class VendorNeutralityScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Ensure the repository has git history for vendor analysis',
+        referenceUrl: 'https://chaoss.community/metric-project-sponsorship/',
         dataSource: 'heuristic',
       });
       return findings;
@@ -175,6 +176,7 @@ export class VendorNeutralityScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Vendor neutrality analysis requires commit history',
+        referenceUrl: 'https://chaoss.community/metric-project-sponsorship/',
         dataSource: 'heuristic',
       });
       return findings;
@@ -196,7 +198,7 @@ export class VendorNeutralityScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Diversify contributors across multiple organizations to reduce single-vendor risk',
-        referenceUrl: 'https://chaoss.community/metric-organizational-diversity/',
+        referenceUrl: 'https://chaoss.community/metric-project-sponsorship/',
         dataSource: 'heuristic',
         metadata: {
           totalCommits: stats.totalCommits,
@@ -215,7 +217,7 @@ export class VendorNeutralityScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Encourage contributions from additional organizations to improve vendor diversity',
-        referenceUrl: 'https://chaoss.community/metric-organizational-diversity/',
+        referenceUrl: 'https://chaoss.community/metric-project-sponsorship/',
         dataSource: 'heuristic',
         metadata: {
           totalCommits: stats.totalCommits,
@@ -234,7 +236,7 @@ export class VendorNeutralityScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Vendor diversity is healthy. Continue encouraging multi-organization contributions.',
-        referenceUrl: 'https://chaoss.community/metric-organizational-diversity/',
+        referenceUrl: 'https://chaoss.community/metric-project-sponsorship/',
         dataSource: 'heuristic',
         metadata: {
           totalCommits: stats.totalCommits,
@@ -255,6 +257,7 @@ export class VendorNeutralityScanner implements Scanner {
       line: null,
       column: null,
       suggestion: 'More unique domains indicates broader organizational participation',
+      referenceUrl: 'https://chaoss.community/metric-project-sponsorship/',
       dataSource: 'heuristic',
       metadata: {
         totalCommits: stats.totalCommits,
@@ -276,6 +279,7 @@ export class VendorNeutralityScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Succession planning documentation is present',
+        referenceUrl: 'https://chaoss.community/metric-project-sponsorship/',
         dataSource: 'local',
         metadata: {
           successionPlanFound: true,
@@ -294,6 +298,7 @@ export class VendorNeutralityScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Add succession planning keywords (succession, bus factor, maintainer transition, emeritus) to GOVERNANCE.md or CONTRIBUTING.md',
+        referenceUrl: 'https://chaoss.community/metric-project-sponsorship/',
         dataSource: 'local',
       });
     }

--- a/src/scanner/inclusive/assumed-knowledge-scanner.ts
+++ b/src/scanner/inclusive/assumed-knowledge-scanner.ts
@@ -111,6 +111,7 @@ export class AssumedKnowledgeScanner implements Scanner {
             line: i + 1,
             column: null,
             suggestion: `Consider explaining what "${op.label}" means or linking to a beginner-friendly guide`,
+            referenceUrl: 'https://www.writethedocs.org/guide/docs-as-code/',
             dataSource: 'local',
           });
           break; // Only report one git operation per line
@@ -151,6 +152,7 @@ export class AssumedKnowledgeScanner implements Scanner {
             line: i + 1,
             column: null,
             suggestion: `Add ${tool.prerequisite} to a Prerequisites section so newcomers know what to install`,
+            referenceUrl: 'https://www.writethedocs.org/guide/docs-as-code/',
             dataSource: 'local',
           });
           break; // Only report one tool per line
@@ -219,6 +221,7 @@ export class AssumedKnowledgeScanner implements Scanner {
           line: i + 1,
           column: match.index + 1,
           suggestion: `Define "${acronym}" on first use, e.g., "${acronym} (Full Name)"`,
+          referenceUrl: 'https://www.writethedocs.org/guide/docs-as-code/',
           dataSource: 'local',
         });
       }
@@ -270,6 +273,7 @@ export class AssumedKnowledgeScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Consider adding a Prerequisites section listing required tools and versions',
+        referenceUrl: 'https://www.writethedocs.org/guide/docs-as-code/',
         dataSource: 'local',
       });
     }

--- a/src/scanner/inclusive/code-scanner.ts
+++ b/src/scanner/inclusive/code-scanner.ts
@@ -310,6 +310,7 @@ export class InclusiveCodeScanner implements Scanner {
                 column: region.startCol + 1,
                 context: line.trim(),
                 suggestion: `Consider using: ${term.replacements.join(', ')}`,
+                referenceUrl: 'https://inclusivenaming.org/',
                 dataSource: 'local',
                 metadata: {
                   term: term.term,

--- a/src/scanner/inclusive/diminishing-scanner.ts
+++ b/src/scanner/inclusive/diminishing-scanner.ts
@@ -211,6 +211,7 @@ export class DiminishingLanguageScanner implements Scanner {
               column: match.index + 1,
               context: line.trim(),
               suggestion: dp.suggestion,
+              referenceUrl: 'https://inclusivenaming.org/',
               dataSource: 'local',
             });
 
@@ -253,6 +254,7 @@ export class DiminishingLanguageScanner implements Scanner {
       file: null,
       line: null,
       column: null,
+      referenceUrl: 'https://inclusivenaming.org/',
       dataSource: 'local',
       suggestion:
         welcomingScore > 85

--- a/src/scanner/security/binary-artifacts.ts
+++ b/src/scanner/security/binary-artifacts.ts
@@ -121,6 +121,7 @@ export class BinaryArtifactScanner implements Scanner {
         line: null,
         column: null,
         suggestion: 'Remove binary files from the source tree. Use a package manager or artifact repository instead.',
+        referenceUrl: 'https://github.com/ossf/scorecard/blob/main/docs/checks.md#binary-artifacts',
         dataSource: 'local',
         metadata: {
           sha256,

--- a/src/scanner/security/branch-protection.ts
+++ b/src/scanner/security/branch-protection.ts
@@ -26,6 +26,7 @@ interface BranchProtectionResponse {
 }
 
 const GITHUB_API_BASE = 'https://api.github.com';
+const BRANCH_PROTECTION_FALLBACK_URL = 'https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches';
 
 export class BranchProtectionScanner implements Scanner {
   readonly name = 'branch-protection';
@@ -36,6 +37,12 @@ export class BranchProtectionScanner implements Scanner {
     const { config, git } = context;
     const token = config.githubToken;
     let counter = 0;
+
+    // Determine referenceUrl — computed from owner/repo when available, else fallback
+    const parsed = git.remoteUrl ? parseGitHubUrl(git.remoteUrl) : null;
+    const referenceUrl = parsed
+      ? `https://github.com/${parsed.owner}/${parsed.repo}/settings/branches`
+      : BRANCH_PROTECTION_FALLBACK_URL;
 
     const makeFinding = (
       severity: Severity,
@@ -54,6 +61,7 @@ export class BranchProtectionScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        referenceUrl,
         dataSource: 'api',
         metadata,
       };
@@ -81,8 +89,7 @@ export class BranchProtectionScanner implements Scanner {
       ];
     }
 
-    // Parse GitHub owner/repo from remote URL
-    const parsed = parseGitHubUrl(git.remoteUrl);
+    // Verify that the parsed URL is a GitHub repository
     if (!parsed) {
       return [
         makeFinding(

--- a/src/scanner/security/dep-pinning-docker.ts
+++ b/src/scanner/security/dep-pinning-docker.ts
@@ -24,6 +24,9 @@ export class DepPinningDockerScanner implements Scanner {
     const findings: Finding[] = [];
     let counter = 0;
 
+    const DEP_PINNING_URL =
+      'https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies';
+
     const makeFinding = (
       severity: Severity,
       message: string,
@@ -42,6 +45,7 @@ export class DepPinningDockerScanner implements Scanner {
         line,
         column: null,
         suggestion,
+        referenceUrl: DEP_PINNING_URL,
         dataSource: 'local',
       };
     };

--- a/src/scanner/security/dep-pinning-packages.ts
+++ b/src/scanner/security/dep-pinning-packages.ts
@@ -20,6 +20,9 @@ export class DepPinningPackagesScanner implements Scanner {
     const findings: Finding[] = [];
     let counter = 0;
 
+    const DEP_PINNING_URL =
+      'https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies';
+
     const makeFinding = (
       severity: Severity,
       message: string,
@@ -38,6 +41,7 @@ export class DepPinningPackagesScanner implements Scanner {
         line,
         column: null,
         suggestion,
+        referenceUrl: DEP_PINNING_URL,
         dataSource: 'local',
       };
     };

--- a/src/scanner/security/openssf-local-checks.ts
+++ b/src/scanner/security/openssf-local-checks.ts
@@ -29,6 +29,8 @@ export class OpenSSFLocalChecksScanner implements Scanner {
     const { repoPath } = context;
     let counter = 0;
 
+    const OPENSSF_LOCAL_URL = 'https://github.com/ossf/scorecard/blob/main/docs/checks.md';
+
     const makeFinding = (
       severity: Severity,
       message: string,
@@ -46,6 +48,7 @@ export class OpenSSFLocalChecksScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        referenceUrl: OPENSSF_LOCAL_URL,
         dataSource: 'local',
         metadata: {
           scorecard_source: 'local',

--- a/src/scanner/security/openssf-scorecard.ts
+++ b/src/scanner/security/openssf-scorecard.ts
@@ -9,6 +9,8 @@ import { Pillar, Severity } from '../../types/index.js';
 import type { Scanner, ScanContext, Finding } from '../../types/index.js';
 
 const SCORECARD_API = 'https://api.securityscorecards.dev/projects';
+const SCORECARD_VIEWER_BASE = 'https://securityscorecards.dev/viewer/?uri=github.com';
+const SCORECARD_FALLBACK_URL = 'https://securityscorecards.dev/';
 
 interface ScorecardCheck {
   name: string;
@@ -60,6 +62,7 @@ export class OpenSSFScorecardScanner implements Scanner {
       severity: Severity,
       message: string,
       suggestion: string,
+      referenceUrl: string,
       metadata?: Record<string, unknown>,
     ): Finding => {
       counter++;
@@ -73,6 +76,7 @@ export class OpenSSFScorecardScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        referenceUrl,
         dataSource: 'api',
         metadata,
       };
@@ -86,6 +90,7 @@ export class OpenSSFScorecardScanner implements Scanner {
           Severity.INFO,
           'OpenSSF Scorecard requires a remote URL — no remote URL available',
           'Push to a GitHub remote to enable Scorecard analysis',
+          SCORECARD_FALLBACK_URL,
         ),
       ];
     }
@@ -97,9 +102,13 @@ export class OpenSSFScorecardScanner implements Scanner {
           Severity.INFO,
           'OpenSSF Scorecard only supports GitHub repositories',
           'Push to GitHub to enable Scorecard analysis',
+          SCORECARD_FALLBACK_URL,
         ),
       ];
     }
+
+    // Build the computed Tier A referenceUrl for this owner/repo
+    const scorecardViewerUrl = `${SCORECARD_VIEWER_BASE}/${parsed.owner}/${parsed.repo}`;
 
     // Query the Scorecard API
     const apiUrl = `${SCORECARD_API}/github.com/${parsed.owner}/${parsed.repo}`;
@@ -113,6 +122,7 @@ export class OpenSSFScorecardScanner implements Scanner {
             Severity.WARNING,
             `OpenSSF Scorecard unavailable for ${parsed.owner}/${parsed.repo} (HTTP ${response.status})`,
             'Ensure the repository is public and indexed by the Scorecard project',
+            scorecardViewerUrl,
             { scorecard_source: 'api', error: response.statusText },
           ),
         ];
@@ -124,6 +134,7 @@ export class OpenSSFScorecardScanner implements Scanner {
           Severity.WARNING,
           `OpenSSF Scorecard unavailable — ${err instanceof Error ? err.message : 'unknown error'}`,
           'Check network connectivity or try again later',
+          scorecardViewerUrl,
           { scorecard_source: 'api' },
         ),
       ];
@@ -141,6 +152,7 @@ export class OpenSSFScorecardScanner implements Scanner {
           : data.score < 8
             ? 'Review scorecard checks with low scores for improvement opportunities'
             : 'Scorecard score is healthy',
+        scorecardViewerUrl,
         {
           scorecard_source: 'api',
           scorecardVersion: data.scorecard.version,
@@ -161,6 +173,7 @@ export class OpenSSFScorecardScanner implements Scanner {
             : check.score < 8
               ? `Consider improving "${check.name}" for better security posture`
               : `"${check.name}" check is healthy`,
+          scorecardViewerUrl,
           {
             scorecard_source: 'api',
             checkName: check.name,

--- a/src/scanner/security/token-permissions.ts
+++ b/src/scanner/security/token-permissions.ts
@@ -41,6 +41,9 @@ export class TokenPermissionsScanner implements Scanner {
     const findings: Finding[] = [];
     let counter = 0;
 
+    const TOKEN_PERMISSIONS_URL =
+      'https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions';
+
     const makeFinding = (
       severity: Severity,
       message: string,
@@ -59,6 +62,7 @@ export class TokenPermissionsScanner implements Scanner {
         line,
         column: null,
         suggestion,
+        referenceUrl: TOKEN_PERMISSIONS_URL,
         dataSource: 'local',
       };
     };

--- a/src/scanner/technical/interaction-templates.ts
+++ b/src/scanner/technical/interaction-templates.ts
@@ -79,6 +79,7 @@ export class InteractionTemplateScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        referenceUrl: 'https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests',
         dataSource: 'local',
         metadata,
       };

--- a/src/scanner/technical/linter-config.ts
+++ b/src/scanner/technical/linter-config.ts
@@ -104,6 +104,7 @@ export class LinterConfigScanner implements Scanner {
       line: null,
       column: null,
       suggestion,
+      referenceUrl: 'https://chaoss.community/metric-code-quality-metrics/',
       dataSource: 'local',
     });
 

--- a/src/scanner/technical/release-cadence.ts
+++ b/src/scanner/technical/release-cadence.ts
@@ -62,6 +62,7 @@ export class ReleaseCadenceScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        referenceUrl: 'https://chaoss.community/metric-release-frequency/',
         dataSource: 'local',
         metadata,
       };

--- a/src/scanner/technical/semver-validation.ts
+++ b/src/scanner/technical/semver-validation.ts
@@ -60,6 +60,7 @@ export class SemVerValidationScanner implements Scanner {
       line: null,
       column: null,
       suggestion,
+      referenceUrl: 'https://semver.org/',
       dataSource: 'local',
       metadata,
     });

--- a/src/scanner/technical/test-coverage.ts
+++ b/src/scanner/technical/test-coverage.ts
@@ -165,6 +165,7 @@ export class TestCoverageScanner implements Scanner {
         line: null,
         column: null,
         suggestion,
+        referenceUrl: 'https://chaoss.community/metric-test-coverage/',
         dataSource: 'local',
         metadata,
       };

--- a/tests/scanner/reference-url.test.ts
+++ b/tests/scanner/reference-url.test.ts
@@ -1,0 +1,646 @@
+/**
+ * Tests for `referenceUrl` population across all scanners.
+ *
+ * Every scanner must set `referenceUrl` on every Finding it creates.
+ * Tier A scanners compute a URL from finding data (repo, package, SPDX ID).
+ * Tier B scanners set a static reference URL linking to the spec/standard.
+ *
+ * RED phase: tests fail until referenceUrl is populated in all scanners.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+    Pillar,
+    Severity,
+    MaturityLevel,
+    ScanDepth,
+    OutputFormat,
+} from '../../src/types/index.js';
+import type { ScanContext, ScannerConfig, Finding } from '../../src/types/index.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function baseConfig(): ScannerConfig {
+    return {
+        maturity: MaturityLevel.INCUBATING,
+        depth: ScanDepth.STANDARD,
+        format: OutputFormat.JSON,
+        output: null,
+        threshold: null,
+        quiet: false,
+        verbose: false,
+        scannerTimeout: 30_000,
+        githubToken: null,
+        zerodbApiKey: null,
+        zerodbProjectId: null,
+        ecosystem: false,
+        ecosystemDepth: 'static',
+        pillars: { disabled: [], weights: {}, disabledScanners: [] },
+        bots: { enabled: true, additional: [], exclude: [] },
+        inclusive: {
+            termListUrl: null,
+            customTerms: {},
+            ignoredTerms: [],
+            excludePatterns: [],
+        },
+    };
+}
+
+function makeContext(repoPath: string, overrides: Partial<ScanContext> = {}): ScanContext {
+    return {
+        repoPath,
+        repoIdentifier: null,
+        maturity: MaturityLevel.INCUBATING,
+        depth: ScanDepth.STANDARD,
+        config: baseConfig(),
+        git: { commitSha: null, branch: null, remoteUrl: null },
+        signal: AbortSignal.timeout(30_000),
+        emit: () => {},
+        ...overrides,
+    };
+}
+
+/**
+ * Assert that every finding in the array has a non-empty referenceUrl string.
+ */
+function assertReferenceUrls(findings: Finding[]): void {
+    expect(findings.length).toBeGreaterThan(0);
+    for (const finding of findings) {
+        expect(typeof finding.referenceUrl).toBe('string');
+        expect((finding.referenceUrl as string).length).toBeGreaterThan(0);
+        expect(finding.referenceUrl).toMatch(/^https?:\/\//);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tier A — Computed referenceUrl (OpenSSF Scorecard)
+// ---------------------------------------------------------------------------
+
+describe('Tier A: OpenSSFScorecardScanner — computed referenceUrl', () => {
+    it('sets referenceUrl to scorecard viewer URL when no remoteUrl (fallback to static)', async () => {
+        const { OpenSSFScorecardScanner } = await import('../../src/scanner/security/openssf-scorecard.js');
+        const scanner = new OpenSSFScorecardScanner();
+        const ctx = makeContext('/tmp/fake-repo');
+        const findings = await scanner.run(ctx);
+        assertReferenceUrls(findings);
+    });
+
+    it('sets computed referenceUrl containing owner/repo when GitHub remote is present', async () => {
+        const { OpenSSFScorecardScanner } = await import('../../src/scanner/security/openssf-scorecard.js');
+        const scanner = new OpenSSFScorecardScanner();
+
+        // Mock fetch to return a scorecard response so we get per-check findings
+        const mockFetch = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 404,
+            statusText: 'Not Found',
+        });
+        vi.stubGlobal('fetch', mockFetch);
+
+        const ctx = makeContext('/tmp/fake-repo', {
+            git: {
+                commitSha: null,
+                branch: 'main',
+                remoteUrl: 'https://github.com/testowner/testrepo',
+            },
+        });
+        const findings = await scanner.run(ctx);
+
+        // Each finding should have a referenceUrl containing owner/repo
+        assertReferenceUrls(findings);
+        for (const finding of findings) {
+            expect(finding.referenceUrl).toContain('testowner');
+            expect(finding.referenceUrl).toContain('testrepo');
+        }
+
+        vi.unstubAllGlobals();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tier A — Computed referenceUrl (Branch Protection)
+// ---------------------------------------------------------------------------
+
+describe('Tier A: BranchProtectionScanner — computed referenceUrl', () => {
+    it('sets referenceUrl with owner/repo in the URL when token is absent (fallback)', async () => {
+        const { BranchProtectionScanner } = await import('../../src/scanner/security/branch-protection.js');
+        const scanner = new BranchProtectionScanner();
+        // No token → returns INFO finding; should still have a referenceUrl
+        const ctx = makeContext('/tmp/fake-repo');
+        const findings = await scanner.run(ctx);
+        assertReferenceUrls(findings);
+    });
+
+    it('sets computed referenceUrl with owner/repo when 404 from GitHub API', async () => {
+        const { BranchProtectionScanner } = await import('../../src/scanner/security/branch-protection.js');
+        const scanner = new BranchProtectionScanner();
+
+        const mockFetch = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 404,
+            statusText: 'Not Found',
+        });
+        vi.stubGlobal('fetch', mockFetch);
+
+        const ctx = makeContext('/tmp/fake-repo', {
+            config: { ...baseConfig(), githubToken: 'test-token' },
+            git: {
+                commitSha: null,
+                branch: 'main',
+                remoteUrl: 'https://github.com/myorg/myrepo',
+            },
+        });
+        const findings = await scanner.run(ctx);
+        assertReferenceUrls(findings);
+        for (const finding of findings) {
+            expect(finding.referenceUrl).toContain('myorg');
+            expect(finding.referenceUrl).toContain('myrepo');
+        }
+
+        vi.unstubAllGlobals();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tier A — Computed referenceUrl (ClearlyDefined)
+// ---------------------------------------------------------------------------
+
+describe('Tier A: ClearlyDefinedScanner — computed referenceUrl per dependency', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ref-url-test-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('sets referenceUrl containing package name and version in the ClearlyDefined URL', async () => {
+        const { ClearlyDefinedScanner } = await import('../../src/scanner/governance/clearly-defined.js');
+
+        // Write a package.json with a single dep
+        fs.writeFileSync(
+            path.join(tmpDir, 'package.json'),
+            JSON.stringify({ dependencies: { axios: '^1.6.0' } }),
+        );
+
+        // Mock fetch — return NOASSERTION so we get an INFO finding
+        const mockFetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ licensed: { declared: 'NOASSERTION' } }),
+        });
+
+        const scanner = new ClearlyDefinedScanner(mockFetch as unknown as typeof fetch);
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+
+        assertReferenceUrls(findings);
+        // The URL should be the ClearlyDefined definition URL containing the package name
+        for (const finding of findings) {
+            expect(finding.referenceUrl).toContain('clearlydefined.io');
+            expect(finding.referenceUrl).toContain('axios');
+        }
+    });
+
+    it('sets fallback referenceUrl when ClearlyDefined API is unavailable', async () => {
+        const { ClearlyDefinedScanner } = await import('../../src/scanner/governance/clearly-defined.js');
+
+        fs.writeFileSync(
+            path.join(tmpDir, 'package.json'),
+            JSON.stringify({ dependencies: { lodash: '4.17.21' } }),
+        );
+
+        const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 503 });
+
+        const scanner = new ClearlyDefinedScanner(mockFetch as unknown as typeof fetch);
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+
+        assertReferenceUrls(findings);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tier A — Computed referenceUrl (License Detection)
+// ---------------------------------------------------------------------------
+
+describe('Tier A: LicenseDetectionScanner — computed referenceUrl (SPDX)', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ref-url-test-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('sets SPDX URL when an MIT license file is detected', async () => {
+        const { LicenseDetectionScanner } = await import('../../src/scanner/governance/license-detection.js');
+        const scanner = new LicenseDetectionScanner();
+
+        fs.writeFileSync(
+            path.join(tmpDir, 'LICENSE'),
+            'MIT License\nPermission is hereby granted, free of charge ...\nTHE SOFTWARE IS PROVIDED "AS IS"',
+        );
+
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+
+        assertReferenceUrls(findings);
+        expect(findings[0].referenceUrl).toContain('spdx.org/licenses/MIT');
+    });
+
+    it('sets a non-empty referenceUrl when no license is found', async () => {
+        const { LicenseDetectionScanner } = await import('../../src/scanner/governance/license-detection.js');
+        const scanner = new LicenseDetectionScanner();
+
+        const ctx = makeContext(tmpDir); // empty dir — no LICENSE file
+        const findings = await scanner.run(ctx);
+
+        assertReferenceUrls(findings);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tier A — Computed referenceUrl (License Content Validation)
+// ---------------------------------------------------------------------------
+
+describe('Tier A: LicenseContentValidationScanner — computed referenceUrl (SPDX)', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ref-url-test-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('sets SPDX URL when MIT license content matches', async () => {
+        const { LicenseContentValidationScanner } = await import(
+            '../../src/scanner/governance/license-content-validation.js'
+        );
+        const scanner = new LicenseContentValidationScanner();
+
+        fs.writeFileSync(
+            path.join(tmpDir, 'LICENSE'),
+            'MIT License\nPermission is hereby granted, free of charge, ...\nTHE SOFTWARE IS PROVIDED "AS IS"',
+        );
+
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+
+        assertReferenceUrls(findings);
+        expect(findings[0].referenceUrl).toContain('spdx.org');
+    });
+
+    it('sets a non-empty referenceUrl when no LICENSE file exists', async () => {
+        const { LicenseContentValidationScanner } = await import(
+            '../../src/scanner/governance/license-content-validation.js'
+        );
+        const scanner = new LicenseContentValidationScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        assertReferenceUrls(findings);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tier B — Security scanners
+// ---------------------------------------------------------------------------
+
+describe('Tier B: Security scanners — static referenceUrl', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ref-url-test-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('TokenPermissionsScanner: no workflow dir → empty findings (no assertions needed)', async () => {
+        const { TokenPermissionsScanner } = await import('../../src/scanner/security/token-permissions.js');
+        const scanner = new TokenPermissionsScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        // Empty dir returns no findings — test the referenceUrl when findings exist
+        // We need to create a workflow file so findings are produced
+        const workflowDir = path.join(tmpDir, '.github', 'workflows');
+        fs.mkdirSync(workflowDir, { recursive: true });
+        fs.writeFileSync(
+            path.join(workflowDir, 'ci.yml'),
+            'name: CI\non: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v3\n',
+        );
+        const findings2 = await scanner.run(ctx);
+        assertReferenceUrls(findings2);
+        for (const f of findings2) {
+            expect(f.referenceUrl).toContain('ossf/scorecard');
+            expect(f.referenceUrl).toContain('token-permissions');
+        }
+    });
+
+    it('DepPinningPackagesScanner: sets referenceUrl on all findings', async () => {
+        const { DepPinningPackagesScanner } = await import('../../src/scanner/security/dep-pinning-packages.js');
+        const scanner = new DepPinningPackagesScanner();
+
+        // Write package.json with unpinned deps
+        fs.writeFileSync(
+            path.join(tmpDir, 'package.json'),
+            JSON.stringify({ dependencies: { lodash: '*', express: '^4.18.0' } }),
+        );
+
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        assertReferenceUrls(findings);
+        for (const f of findings) {
+            expect(f.referenceUrl).toContain('ossf/scorecard');
+            expect(f.referenceUrl).toContain('pinned-dependencies');
+        }
+    });
+
+    it('DepPinningDockerScanner: sets referenceUrl on all findings', async () => {
+        const { DepPinningDockerScanner } = await import('../../src/scanner/security/dep-pinning-docker.js');
+        const scanner = new DepPinningDockerScanner();
+
+        fs.writeFileSync(path.join(tmpDir, 'Dockerfile'), 'FROM ubuntu:latest\nRUN echo hello\n');
+
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        assertReferenceUrls(findings);
+        for (const f of findings) {
+            expect(f.referenceUrl).toContain('ossf/scorecard');
+            expect(f.referenceUrl).toContain('pinned-dependencies');
+        }
+    });
+
+    it('BinaryArtifactScanner: sets referenceUrl on binary findings', async () => {
+        const { BinaryArtifactScanner } = await import('../../src/scanner/security/binary-artifacts.js');
+        const scanner = new BinaryArtifactScanner();
+
+        // Create a fake .exe binary
+        fs.writeFileSync(path.join(tmpDir, 'test.exe'), Buffer.from([0x4D, 0x5A, 0x00, 0x00]));
+
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        assertReferenceUrls(findings);
+        for (const f of findings) {
+            expect(f.referenceUrl).toContain('ossf/scorecard');
+            expect(f.referenceUrl).toContain('binary-artifacts');
+        }
+    });
+
+    it('OpenSSFLocalChecksScanner: sets referenceUrl on all findings', async () => {
+        const { OpenSSFLocalChecksScanner } = await import('../../src/scanner/security/openssf-local-checks.js');
+        const scanner = new OpenSSFLocalChecksScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        assertReferenceUrls(findings);
+        for (const f of findings) {
+            expect(f.referenceUrl).toContain('ossf/scorecard');
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tier B — Governance scanners
+// ---------------------------------------------------------------------------
+
+describe('Tier B: Governance scanners — static referenceUrl', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ref-url-test-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('DepLicenseScanningScanner: sets referenceUrl to spdx.org on all findings', async () => {
+        const { DepLicenseScanningScanner } = await import('../../src/scanner/governance/dep-license-scanning.js');
+        const scanner = new DepLicenseScanningScanner();
+        const ctx = makeContext(tmpDir); // no manifest files → INFO finding
+        const findings = await scanner.run(ctx);
+        assertReferenceUrls(findings);
+        for (const f of findings) {
+            expect(f.referenceUrl).toContain('spdx.org');
+        }
+    });
+
+    it('VendorNeutralityScanner: sets referenceUrl to chaoss.community on all findings', async () => {
+        const { VendorNeutralityScanner } = await import('../../src/scanner/governance/vendor-neutrality.js');
+        const scanner = new VendorNeutralityScanner();
+        // Run in a temp dir that has no git history → INFO finding
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        assertReferenceUrls(findings);
+        for (const f of findings) {
+            expect(f.referenceUrl).toContain('chaoss.community');
+        }
+    });
+
+    it('BusFactorScanner: sets referenceUrl to chaoss.community on all findings', async () => {
+        const { BusFactorScanner } = await import('../../src/scanner/governance/bus-factor.js');
+        const scanner = new BusFactorScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        assertReferenceUrls(findings);
+        for (const f of findings) {
+            expect(f.referenceUrl).toContain('chaoss.community');
+        }
+    });
+
+    it('GovernanceDetectionScanner: sets referenceUrl to opensource.guide on all findings', async () => {
+        const { GovernanceDetectionScanner } = await import('../../src/scanner/governance/governance-detection.js');
+        const scanner = new GovernanceDetectionScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        assertReferenceUrls(findings);
+        for (const f of findings) {
+            expect(f.referenceUrl).toContain('opensource.guide');
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tier B — Community scanners
+// ---------------------------------------------------------------------------
+
+describe('Tier B: Community scanners — static referenceUrl', () => {
+    it('BurnoutDetectionScanner: sets referenceUrl to chaoss.community on all findings', async () => {
+        const { BurnoutDetectionScanner } = await import('../../src/scanner/community/burnout-detection.js');
+        const scanner = new BurnoutDetectionScanner();
+        // No token → INFO finding
+        const ctx = makeContext('/tmp/fake-repo');
+        const findings = await scanner.run(ctx);
+        assertReferenceUrls(findings);
+        for (const f of findings) {
+            expect(f.referenceUrl).toContain('chaoss.community');
+        }
+    });
+
+    it('FundingScanner: sets referenceUrl to chaoss.community on all findings', async () => {
+        const { FundingScanner } = await import('../../src/scanner/community/funding.js');
+        const scanner = new FundingScanner();
+        const ctx = makeContext('/tmp/fake-repo');
+        const findings = await scanner.run(ctx);
+        assertReferenceUrls(findings);
+        for (const f of findings) {
+            expect(f.referenceUrl).toContain('chaoss.community');
+        }
+    });
+
+    it('IssueClosureScanner: sets referenceUrl to chaoss.community on all findings', async () => {
+        const { IssueClosureScanner } = await import('../../src/scanner/community/issue-closure.js');
+        const scanner = new IssueClosureScanner();
+        const ctx = makeContext('/tmp/fake-repo');
+        const findings = await scanner.run(ctx);
+        assertReferenceUrls(findings);
+        for (const f of findings) {
+            expect(f.referenceUrl).toContain('chaoss.community');
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tier B — AI Readiness scanners
+// ---------------------------------------------------------------------------
+
+describe('Tier B: AI Readiness scanners — static referenceUrl', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ref-url-test-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('AgenticRulesScanner: sets referenceUrl to chaoss.community on all findings', async () => {
+        const { AgenticRulesScanner } = await import('../../src/scanner/ai-readiness/agentic-rules.js');
+        const scanner = new AgenticRulesScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        assertReferenceUrls(findings);
+        for (const f of findings) {
+            expect(f.referenceUrl).toContain('chaoss.community');
+        }
+    });
+
+    it('ModelCardDetectionScanner: sets referenceUrl to huggingface.co on all findings', async () => {
+        const { ModelCardDetectionScanner } = await import('../../src/scanner/ai-readiness/model-card-detection.js');
+        const scanner = new ModelCardDetectionScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        assertReferenceUrls(findings);
+        for (const f of findings) {
+            expect(f.referenceUrl).toContain('huggingface.co');
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tier B — Inclusive scanners
+// ---------------------------------------------------------------------------
+
+describe('Tier B: Inclusive scanners — static referenceUrl', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ref-url-test-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('InclusiveCodeScanner: sets referenceUrl on all findings when terms are found', async () => {
+        const { InclusiveCodeScanner } = await import('../../src/scanner/inclusive/code-scanner.js');
+        const scanner = new InclusiveCodeScanner();
+
+        // Write a JS file with a non-inclusive term in a comment
+        fs.writeFileSync(path.join(tmpDir, 'test.js'), '// master branch config\nconst x = 1;\n');
+
+        const ctx = makeContext(tmpDir, {
+            config: {
+                ...baseConfig(),
+                inclusive: {
+                    termListUrl: null,
+                    customTerms: {
+                        master: [{ term: 'master', tier: 1, replacements: ['main', 'primary'] }],
+                    },
+                    ignoredTerms: [],
+                    excludePatterns: [],
+                },
+            },
+        });
+        const findings = await scanner.run(ctx);
+
+        // If there are findings, they must have referenceUrl
+        if (findings.length > 0) {
+            assertReferenceUrls(findings);
+            for (const f of findings) {
+                expect(f.referenceUrl).toContain('inclusivenaming.org');
+            }
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tier B — Technical scanners
+// ---------------------------------------------------------------------------
+
+describe('Tier B: Technical scanners — static referenceUrl', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ref-url-test-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('InteractionTemplateScanner: sets referenceUrl to docs.github.com on all findings', async () => {
+        const { InteractionTemplateScanner } = await import('../../src/scanner/technical/interaction-templates.js');
+        const scanner = new InteractionTemplateScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        assertReferenceUrls(findings);
+        for (const f of findings) {
+            expect(f.referenceUrl).toContain('docs.github.com');
+        }
+    });
+
+    it('SemVerValidationScanner: sets referenceUrl to semver.org on all findings', async () => {
+        const { SemVerValidationScanner } = await import('../../src/scanner/technical/semver-validation.js');
+        const scanner = new SemVerValidationScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        assertReferenceUrls(findings);
+        for (const f of findings) {
+            expect(f.referenceUrl).toContain('semver.org');
+        }
+    });
+
+    it('ReleaseCadenceScanner: sets referenceUrl to chaoss.community on all findings', async () => {
+        const { ReleaseCadenceScanner } = await import('../../src/scanner/technical/release-cadence.js');
+        const scanner = new ReleaseCadenceScanner();
+        const ctx = makeContext(tmpDir);
+        const findings = await scanner.run(ctx);
+        assertReferenceUrls(findings);
+        for (const f of findings) {
+            expect(f.referenceUrl).toContain('chaoss.community');
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- Tier A (5 scanners): compute `referenceUrl` dynamically from repo/package/SPDX data — `openssf-scorecard` (Scorecard viewer URL), `branch-protection` (repo settings URL), `clearly-defined` (per-dep ClearlyDefined definition URL), `license-detection` (SPDX license HTML page), `license-content-validation` (SPDX license HTML page)
- Tier B (38 scanners): set a static `referenceUrl` pointing to the authoritative spec/standard motivating each check — CHAOSS metrics, HuggingFace docs, SPDX, GitHub Docs, inclusivenaming.org, semver.org, opensource.guide, OpenSSF Scorecard docs, reuse.software, writethedocs.org
- 28 new tests in `tests/scanner/reference-url.test.ts` — all pass (RED commit `b5e71c7`, GREEN commit `bb7dbf2`)

## Test plan

- [x] `npx vitest run tests/scanner/reference-url.test.ts` — 28/28 pass
- [x] Full test suite — all scanner tests pass; cli-integration failures are pre-existing and unrelated

Closes #105