### PR TITLE
feat: support .quaid-scanner-ignore for project-level scan exclusions

### DIFF
--- a/.quaid-scanner-ignore
+++ b/.quaid-scanner-ignore
@@ -1,0 +1,6 @@
+# Test fixtures — contain flagged terms intentionally as string assertions
+tests/
+
+# Documentation that uses terms as examples of what to avoid
+docs/PRD.md
+docs/PRD-v2.md

--- a/src/scanner/inclusive/code-scanner.ts
+++ b/src/scanner/inclusive/code-scanner.ts
@@ -10,6 +10,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { glob } from 'glob';
 import { TermListManager } from './term-list.js';
+import { loadIgnorePatterns } from './ignore-file.js';
 import { Pillar, Severity } from '../../types/index.js';
 import type { Scanner, ScanContext, Finding } from '../../types/index.js';
 
@@ -184,8 +185,13 @@ export class InclusiveCodeScanner implements Scanner {
       return [];
     }
 
+    // Load ignore patterns from .quaid-scanner-ignore and config
+    const fileIgnorePatterns = await loadIgnorePatterns(repoPath);
+    const configPatterns = inclusiveConfig.excludePatterns;
+    const userExcludes = [...fileIgnorePatterns, ...configPatterns];
+
     // Find all matching code files
-    const files = await this.findCodeFiles(repoPath);
+    const files = await this.findCodeFiles(repoPath, userExcludes);
     const findings: Finding[] = [];
     let findingCounter = 0;
 
@@ -396,10 +402,17 @@ export class InclusiveCodeScanner implements Scanner {
 
   /**
    * Find all code files matching the supported extensions,
-   * excluding directories like node_modules, dist, etc.
+   * excluding hardcoded directories plus any user-supplied patterns.
+   *
+   * @param repoPath - Absolute path to the root of the repository
+   * @param userExcludes - Additional glob patterns to exclude (from
+   *   .quaid-scanner-ignore and config.inclusive.excludePatterns)
    */
-  private async findCodeFiles(repoPath: string): Promise<string[]> {
-    const ignore = EXCLUDED_DIRS.map((d) => `**/${d}**`);
+  private async findCodeFiles(repoPath: string, userExcludes: string[] = []): Promise<string[]> {
+    const ignore = [
+      ...EXCLUDED_DIRS.map((d) => `**/${d}**`),
+      ...userExcludes,
+    ];
 
     const files = await glob(CODE_EXTENSIONS, {
       cwd: repoPath,

--- a/src/scanner/inclusive/doc-scanner.ts
+++ b/src/scanner/inclusive/doc-scanner.ts
@@ -12,6 +12,7 @@ import { glob } from 'glob';
 import type { Scanner, ScanContext, Finding } from '../../types/index.js';
 import { Pillar, Severity } from '../../types/index.js';
 import { TermListManager, type LoadedTerm } from './term-list.js';
+import { loadIgnorePatterns } from './ignore-file.js';
 
 /** File extensions considered documentation files. */
 const DOC_EXTENSIONS = ['md', 'txt', 'rst', 'adoc', 'html'];
@@ -100,8 +101,13 @@ export class InclusiveDocScanner implements Scanner {
       return [];
     }
 
+    // Load ignore patterns from .quaid-scanner-ignore and config
+    const fileIgnorePatterns = await loadIgnorePatterns(repoPath);
+    const configPatterns = inclusiveConfig.excludePatterns;
+    const userExcludes = [...fileIgnorePatterns, ...configPatterns];
+
     // Find documentation files
-    const files = await this.findDocFiles(repoPath);
+    const files = await this.findDocFiles(repoPath, userExcludes);
     const findings: Finding[] = [];
 
     for (const absolutePath of files) {
@@ -115,11 +121,18 @@ export class InclusiveDocScanner implements Scanner {
 
   /**
    * Find all documentation files in the repository, excluding
-   * node_modules, vendor, and .git directories.
+   * node_modules, vendor, and .git directories plus any user-supplied patterns.
+   *
+   * @param repoPath - Absolute path to the root of the repository
+   * @param userExcludes - Additional glob patterns to exclude (from
+   *   .quaid-scanner-ignore and config.inclusive.excludePatterns)
    */
-  private async findDocFiles(repoPath: string): Promise<string[]> {
+  private async findDocFiles(repoPath: string, userExcludes: string[] = []): Promise<string[]> {
     const patterns = DOC_EXTENSIONS.map((ext) => `**/*.${ext}`);
-    const ignorePatterns = EXCLUDED_DIRS.map((dir) => `${dir}/**`);
+    const ignorePatterns = [
+      ...EXCLUDED_DIRS.map((dir) => `${dir}/**`),
+      ...userExcludes,
+    ];
 
     const files = await glob(patterns, {
       cwd: repoPath,

--- a/src/scanner/inclusive/ignore-file.ts
+++ b/src/scanner/inclusive/ignore-file.ts
@@ -1,0 +1,52 @@
+/**
+ * Loader for .quaid-scanner-ignore files.
+ *
+ * Reads project-level exclusion patterns from a .quaid-scanner-ignore
+ * file at the root of the scanned repository. The format is one glob
+ * pattern per line; lines starting with # are treated as comments and
+ * blank lines are ignored.
+ */
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+/**
+ * Normalize a raw pattern line into a glob ignore pattern.
+ *
+ * Patterns that end with a `/` (directory patterns like `tests/`) are
+ * converted to recursive glob patterns (`tests/**`) so that glob's
+ * `ignore` option correctly excludes all files within the directory.
+ *
+ * @param pattern - Raw pattern string from the ignore file
+ * @returns Normalized glob pattern
+ */
+function normalizePattern(pattern: string): string {
+    if (pattern.endsWith('/')) {
+        return `${pattern}**`;
+    }
+    return pattern;
+}
+
+/**
+ * Load exclusion patterns from a .quaid-scanner-ignore file.
+ *
+ * Directory patterns (ending with `/`) are automatically normalized to
+ * recursive glob patterns (e.g. `tests/` → `tests/**`).
+ *
+ * @param repoPath - Absolute path to the root of the repository being scanned
+ * @returns Array of glob patterns to exclude, or an empty array if the file
+ *          does not exist or cannot be read
+ */
+export async function loadIgnorePatterns(repoPath: string): Promise<string[]> {
+    const filePath = path.join(repoPath, '.quaid-scanner-ignore');
+    try {
+        const content = await readFile(filePath, 'utf-8');
+        return content
+            .split('\n')
+            .map((line) => line.trim())
+            .filter((line) => line.length > 0 && !line.startsWith('#'))
+            .map(normalizePattern);
+    } catch {
+        return [];
+    }
+}

--- a/tests/scanner/inclusive/code-scanner.test.ts
+++ b/tests/scanner/inclusive/code-scanner.test.ts
@@ -499,4 +499,60 @@ describe('InclusiveCodeScanner', () => {
       expect(abortFindings).toHaveLength(0);
     });
   });
+
+  describe('excludePatterns config integration', () => {
+    it('excludes files matching patterns in config.inclusive.excludePatterns', async () => {
+      writeFixture(tmpDir, 'tests/app.test.ts', [
+        "// expect(terms).not.toContain('whitelist')",
+      ].join('\n'));
+      writeFixture(tmpDir, 'src/app.ts', [
+        '// whitelist is a non-inclusive term',
+      ].join('\n'));
+
+      const ctx = createContext(tmpDir, {
+        inclusive: {
+          termListUrl: null,
+          customTerms: {},
+          ignoredTerms: [],
+          excludePatterns: ['tests/**'],
+        },
+      });
+      const findings = await scanner.run(ctx);
+
+      // tests/app.test.ts should not be scanned
+      const testFindings = findings.filter((f) => f.file?.includes('tests/'));
+      expect(testFindings).toHaveLength(0);
+
+      // src/app.ts should still be scanned
+      const srcFindings = findings.filter((f) => f.file?.includes('src/'));
+      expect(srcFindings.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('excludes files matching patterns from .quaid-scanner-ignore file', async () => {
+      // Write a .quaid-scanner-ignore file
+      fs.writeFileSync(
+        path.join(tmpDir, '.quaid-scanner-ignore'),
+        '# Test files\ntests/\n',
+        'utf-8',
+      );
+
+      writeFixture(tmpDir, 'tests/app.test.ts', [
+        "// expect(terms).not.toContain('whitelist')",
+      ].join('\n'));
+      writeFixture(tmpDir, 'src/app.ts', [
+        '// whitelist is a non-inclusive term',
+      ].join('\n'));
+
+      const ctx = createContext(tmpDir);
+      const findings = await scanner.run(ctx);
+
+      // tests/app.test.ts should not be scanned (excluded by .quaid-scanner-ignore)
+      const testFindings = findings.filter((f) => f.file?.includes('tests/'));
+      expect(testFindings).toHaveLength(0);
+
+      // src/app.ts should still be scanned
+      const srcFindings = findings.filter((f) => f.file?.includes('src/'));
+      expect(srcFindings.length).toBeGreaterThanOrEqual(1);
+    });
+  });
 });

--- a/tests/scanner/inclusive/doc-scanner.test.ts
+++ b/tests/scanner/inclusive/doc-scanner.test.ts
@@ -400,4 +400,54 @@ describe('InclusiveDocScanner', () => {
       expect(masterFindings).toHaveLength(0);
     });
   });
+
+  describe('excludePatterns config integration', () => {
+    it('excludes files matching patterns in config.inclusive.excludePatterns', async () => {
+      writeFixture(tmpDir, 'docs/PRD.md', 'The whitelist and master-slave sections.\n');
+      writeFixture(tmpDir, 'guide.md', 'The whitelist entry here.\n');
+
+      const context = createScanContext(tmpDir, {
+        inclusive: {
+          termListUrl: null,
+          customTerms: {},
+          ignoredTerms: [],
+          excludePatterns: ['docs/**'],
+        },
+      });
+
+      const findings = await scanner.run(context);
+
+      // docs/PRD.md should not be scanned
+      const docFindings = findings.filter((f) => f.file?.startsWith('docs/'));
+      expect(docFindings).toHaveLength(0);
+
+      // guide.md should still be scanned
+      const guideFindings = findings.filter((f) => f.file === 'guide.md');
+      expect(guideFindings.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('excludes files matching patterns from .quaid-scanner-ignore file', async () => {
+      // Write a .quaid-scanner-ignore file
+      fs.writeFileSync(
+        path.join(tmpDir, '.quaid-scanner-ignore'),
+        '# Documentation\ndocs/\n',
+        'utf-8',
+      );
+
+      writeFixture(tmpDir, 'docs/PRD.md', 'The whitelist and master-slave sections.\n');
+      writeFixture(tmpDir, 'guide.md', 'The whitelist entry here.\n');
+
+      const context = createScanContext(tmpDir);
+
+      const findings = await scanner.run(context);
+
+      // docs/PRD.md should not be scanned (excluded by .quaid-scanner-ignore)
+      const docFindings = findings.filter((f) => f.file?.startsWith('docs/'));
+      expect(docFindings).toHaveLength(0);
+
+      // guide.md should still be scanned
+      const guideFindings = findings.filter((f) => f.file === 'guide.md');
+      expect(guideFindings.length).toBeGreaterThanOrEqual(1);
+    });
+  });
 });

--- a/tests/scanner/inclusive/ignore-file.test.ts
+++ b/tests/scanner/inclusive/ignore-file.test.ts
@@ -38,7 +38,7 @@ describe('loadIgnorePatterns', () => {
     });
 
     describe('when .quaid-scanner-ignore exists', () => {
-        it('returns parsed patterns from the file', async () => {
+        it('returns parsed patterns from the file, normalizing directory patterns', async () => {
             fs.writeFileSync(
                 path.join(tmpDir, '.quaid-scanner-ignore'),
                 'tests/\ndocs/PRD.md\n',
@@ -46,7 +46,8 @@ describe('loadIgnorePatterns', () => {
             );
 
             const result = await loadIgnorePatterns(tmpDir);
-            expect(result).toEqual(['tests/', 'docs/PRD.md']);
+            // Directory patterns (ending with /) are normalized to glob recursive form
+            expect(result).toEqual(['tests/**', 'docs/PRD.md']);
         });
 
         it('skips blank lines', async () => {
@@ -57,7 +58,7 @@ describe('loadIgnorePatterns', () => {
             );
 
             const result = await loadIgnorePatterns(tmpDir);
-            expect(result).toEqual(['tests/', 'docs/PRD.md']);
+            expect(result).toEqual(['tests/**', 'docs/PRD.md']);
         });
 
         it('skips lines starting with #', async () => {
@@ -68,7 +69,7 @@ describe('loadIgnorePatterns', () => {
             );
 
             const result = await loadIgnorePatterns(tmpDir);
-            expect(result).toEqual(['tests/', 'docs/PRD.md']);
+            expect(result).toEqual(['tests/**', 'docs/PRD.md']);
         });
 
         it('trims whitespace from pattern lines', async () => {
@@ -79,7 +80,7 @@ describe('loadIgnorePatterns', () => {
             );
 
             const result = await loadIgnorePatterns(tmpDir);
-            expect(result).toEqual(['tests/', 'docs/PRD.md']);
+            expect(result).toEqual(['tests/**', 'docs/PRD.md']);
         });
 
         it('returns multiple patterns when multiple non-comment lines present', async () => {
@@ -98,7 +99,8 @@ describe('loadIgnorePatterns', () => {
             );
 
             const result = await loadIgnorePatterns(tmpDir);
-            expect(result).toEqual(['tests/', 'docs/PRD.md', 'docs/PRD-v2.md', 'vendor/']);
+            // Directory patterns normalized; file patterns unchanged
+            expect(result).toEqual(['tests/**', 'docs/PRD.md', 'docs/PRD-v2.md', 'vendor/**']);
         });
 
         it('returns empty array when file contains only comments and blank lines', async () => {

--- a/tests/scanner/inclusive/ignore-file.test.ts
+++ b/tests/scanner/inclusive/ignore-file.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for the .quaid-scanner-ignore file loader.
+ *
+ * Covers: missing file, valid patterns, blank-line filtering,
+ * comment filtering, whitespace trimming, and multiple patterns.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { loadIgnorePatterns } from '../../../src/scanner/inclusive/ignore-file.js';
+
+function createTempDir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'ignore-file-test-'));
+}
+
+function removeTempDir(dir: string): void {
+    fs.rmSync(dir, { recursive: true, force: true });
+}
+
+describe('loadIgnorePatterns', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = createTempDir();
+    });
+
+    afterEach(() => {
+        removeTempDir(tmpDir);
+    });
+
+    describe('when .quaid-scanner-ignore does not exist', () => {
+        it('returns an empty array', async () => {
+            const result = await loadIgnorePatterns(tmpDir);
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe('when .quaid-scanner-ignore exists', () => {
+        it('returns parsed patterns from the file', async () => {
+            fs.writeFileSync(
+                path.join(tmpDir, '.quaid-scanner-ignore'),
+                'tests/\ndocs/PRD.md\n',
+                'utf-8',
+            );
+
+            const result = await loadIgnorePatterns(tmpDir);
+            expect(result).toEqual(['tests/', 'docs/PRD.md']);
+        });
+
+        it('skips blank lines', async () => {
+            fs.writeFileSync(
+                path.join(tmpDir, '.quaid-scanner-ignore'),
+                'tests/\n\n\ndocs/PRD.md\n',
+                'utf-8',
+            );
+
+            const result = await loadIgnorePatterns(tmpDir);
+            expect(result).toEqual(['tests/', 'docs/PRD.md']);
+        });
+
+        it('skips lines starting with #', async () => {
+            fs.writeFileSync(
+                path.join(tmpDir, '.quaid-scanner-ignore'),
+                '# This is a comment\ntests/\n# Another comment\ndocs/PRD.md\n',
+                'utf-8',
+            );
+
+            const result = await loadIgnorePatterns(tmpDir);
+            expect(result).toEqual(['tests/', 'docs/PRD.md']);
+        });
+
+        it('trims whitespace from pattern lines', async () => {
+            fs.writeFileSync(
+                path.join(tmpDir, '.quaid-scanner-ignore'),
+                '  tests/  \n  docs/PRD.md  \n',
+                'utf-8',
+            );
+
+            const result = await loadIgnorePatterns(tmpDir);
+            expect(result).toEqual(['tests/', 'docs/PRD.md']);
+        });
+
+        it('returns multiple patterns when multiple non-comment lines present', async () => {
+            fs.writeFileSync(
+                path.join(tmpDir, '.quaid-scanner-ignore'),
+                [
+                    '# Test fixtures',
+                    'tests/',
+                    '',
+                    '# Documentation',
+                    'docs/PRD.md',
+                    'docs/PRD-v2.md',
+                    'vendor/',
+                ].join('\n'),
+                'utf-8',
+            );
+
+            const result = await loadIgnorePatterns(tmpDir);
+            expect(result).toEqual(['tests/', 'docs/PRD.md', 'docs/PRD-v2.md', 'vendor/']);
+        });
+
+        it('returns empty array when file contains only comments and blank lines', async () => {
+            fs.writeFileSync(
+                path.join(tmpDir, '.quaid-scanner-ignore'),
+                '# Only comments\n# Nothing else\n\n',
+                'utf-8',
+            );
+
+            const result = await loadIgnorePatterns(tmpDir);
+            expect(result).toEqual([]);
+        });
+    });
+});


### PR DESCRIPTION
Closes #113

## Problem

The inclusive scanners flag terms in test files and documentation that legitimately contain those terms (e.g. `expect(terms).not.toContain('whitelist')` in test assertions). There was no way for project maintainers to tell the scanner which paths to skip.

## Solution

- **New module** `src/scanner/inclusive/ignore-file.ts`: exports `loadIgnorePatterns(repoPath)` which reads `.quaid-scanner-ignore` from the repo root, parses one glob pattern per line, strips comments (`#`) and blank lines, and normalizes directory patterns (`tests/` → `tests/**`) for correct glob behavior.
- **`InclusiveCodeScanner`** (`src/scanner/inclusive/code-scanner.ts`): `findCodeFiles()` now accepts user-supplied excludes, merging patterns from both `.quaid-scanner-ignore` and `config.inclusive.excludePatterns` into the existing hardcoded `EXCLUDED_DIRS`.
- **`InclusiveDocScanner`** (`src/scanner/inclusive/doc-scanner.ts`): same change applied to `findDocFiles()`.
- **`.quaid-scanner-ignore`** added to this repo to exclude `tests/` (intentional term usage in assertions) and `docs/PRD.md` / `docs/PRD-v2.md` (use terms as examples of what to avoid).

The `naming-scanner`, `assumed-knowledge-scanner`, and `diminishing-scanner` scanners do not enumerate files via glob (they check specific known files like `package.json` or use targeted file lists), so they do not need this change.

## Test Plan

**New test file:** `tests/scanner/inclusive/ignore-file.test.ts` — 7 unit tests covering:
- Returns `[]` when `.quaid-scanner-ignore` does not exist
- Returns parsed patterns when file exists
- Skips blank lines
- Skips comment lines (`#` prefix)
- Trims whitespace from pattern lines
- Returns multiple patterns when multiple non-comment lines present
- Returns `[]` for comment/blank-only file
- Directory patterns normalized to `/**` form

**Integration tests** added to existing test files:
- `code-scanner.test.ts`: 2 new tests verifying `config.inclusive.excludePatterns` and `.quaid-scanner-ignore` file patterns exclude matched files
- `doc-scanner.test.ts`: 2 new tests with same coverage

**Commands run:**

```
npx vitest run
```

Result: 1487 tests passed, 0 test failures. Coverage: 97.58%.

**Verification:**
```
node dist/cli.js . --depth quick --format markdown --quiet 2>/dev/null | grep -c "inclusive-code-scanner"
```
Result: 14 (all from `src/scanner/inclusive/term-list.ts` source definitions, none from `tests/`).

## Risk

Low. Additive change — no existing behavior modified. Scanners that previously ignored only hardcoded dirs now also respect user patterns. If `.quaid-scanner-ignore` is absent, behavior is identical to before.