### PR TITLE
meta: v0.1.2 release prep — CHANGELOG, PRD v2.5, ignore-file cleanup

### DIFF
--- a/.quaid-scanner-ignore
+++ b/.quaid-scanner-ignore
@@ -4,3 +4,9 @@ tests/
 # Documentation that uses terms as examples of what to avoid
 docs/PRD.md
 docs/PRD-v2.md
+
+# Generated coverage reports — HTML snapshots contain flagged terms in code excerpts
+coverage/
+
+# Scanner source files that define the term list itself
+src/scanner/inclusive/term-list.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.2] - 2026-05-27
+## [0.1.2] - 2026-05-30
 
 ### Added
 
@@ -24,6 +24,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (vulnerability disclosure policy), `.github/SUPPORT.md` (help channel guide). (#78, #79, #80, #97, #99)
 - **GitHub issue templates**: structured forms for bug reports, feature requests, and false positives;
   blank issues disabled with links to Discussions and Security Advisories. (#81)
+- **`dataSource` field on findings** — every finding now carries a `dataSource` tag (`'api'`,
+  `'local'`, or `'heuristic'`) indicating where the data came from. Rendered in markdown reports as
+  `_(source: external API)_` etc. (#103, #104)
+- **Finding metadata rendered in markdown** — the markdown reporter now surfaces `context` (the
+  triggering code/value), `dataSource`, and key metadata fields (`checkName`, `checkScore`,
+  `branch`, `overallScore`) for each critical finding. (#104)
+- **`referenceUrl` on all 43 scanners** — every scanner now populates `referenceUrl` with either a
+  dynamically computed link to the authoritative source (OpenSSF Scorecard viewer, ClearlyDefined
+  definition page, SPDX license page, GitHub branch settings) or a static link to the spec or
+  standard that motivates the check (CHAOSS metric, INI overview, semver.org, etc.). (#105)
+- **Score Rationale section** — every markdown report ends with a table showing each pillar's
+  weight, raw score, and weighted contribution to the overall score. (#106)
+- **`.quaid-scanner-ignore` file support** — place a `.quaid-scanner-ignore` file at the root of
+  any scanned repository to exclude paths from inclusive language scanning. Format follows
+  `.gitignore` conventions (one glob pattern per line, `#` comments, blank lines ignored). Also
+  activates the existing but previously unimplemented `--exclude-pattern` config option. (#113)
 
 ### Changed
 
@@ -40,6 +56,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to eliminate spurious coverage gaps. (#56, #57)
 - `package.json` dependency versions pinned to `^` ranges with locked minor versions to improve
   supply-chain reproducibility. (#84, #85)
+- `InclusiveConfig.excludePatterns` was declared in the type but never applied by any scanner;
+  both `code-scanner` and `doc-scanner` now merge config-supplied patterns into their glob ignore
+  arrays. (#113)
 
 ## [0.1.1] - 2026-05-04
 

--- a/docs/PRD-v2.md
+++ b/docs/PRD-v2.md
@@ -1,4 +1,4 @@
-# Quaid's OSS Repo Scanner - PRD v2.4
+# Quaid's OSS Repo Scanner - PRD v2.5
 
 ## Executive Summary
 
@@ -2224,12 +2224,13 @@ Ensure every finding is self-documenting: users can verify the source of each cl
 
 | # | Story | Issue | Status |
 |---|-------|-------|--------|
-| 13.1 | dataSource field in Finding type | #103 | 📋 Planned |
-| 13.2 | Markdown metadata and dataSource rendering | #104 | 📋 Planned |
-| 13.3 | referenceUrl in all 43 scanners | #105 | 📋 Planned |
-| 13.4 | Score Rationale section in markdown report | #106 | 📋 Planned |
+| 13.1 | dataSource field in Finding type | #103 | ✅ Done |
+| 13.2 | Markdown metadata and dataSource rendering | #104 | ✅ Done |
+| 13.3 | referenceUrl in all 43 scanners | #105 | ✅ Done |
+| 13.4 | Score Rationale section in markdown report | #106 | ✅ Done |
+| 13.5 | `.quaid-scanner-ignore` file support | #113 | ✅ Done |
 
-### Story 13.1: dataSource Field in Finding Metadata (TRUST-01) 📋
+### Story 13.1: dataSource Field in Finding Metadata (TRUST-01) ✅
 **As a** Developer Agent or OSPO Manager
 **I want** each finding to indicate whether its data came from an authoritative API, a local file check, or a heuristic estimate
 **So that** I can calibrate my trust in the finding's reliability
@@ -2250,7 +2251,7 @@ Ensure every finding is self-documenting: users can verify the source of each cl
 
 ---
 
-### Story 13.2: Markdown Evidence Rendering (TRUST-02) 📋
+### Story 13.2: Markdown Evidence Rendering (TRUST-02) ✅
 **As a** OSPO Manager or Security Engineer reading a markdown report
 **I want** finding metadata and data source rendered inline
 **So that** I don't need to re-run the scan in JSON mode to understand the evidence
@@ -2270,7 +2271,7 @@ Ensure every finding is self-documenting: users can verify the source of each cl
 
 ---
 
-### Story 13.3: referenceUrl in All Scanners (TRUST-03) 📋
+### Story 13.3: referenceUrl in All Scanners (TRUST-03) ✅
 **As a** Developer Agent or human reader
 **I want** every finding to include a `referenceUrl` linking to the authoritative source, standard, or settings page
 **So that** I can verify the finding independently without reconstructing URLs manually
@@ -2291,7 +2292,7 @@ Ensure every finding is self-documenting: users can verify the source of each cl
 
 ---
 
-### Story 13.4: Score Rationale Section (TRUST-04) 📋
+### Story 13.4: Score Rationale Section (TRUST-04) ✅
 **As a** OSPO Manager receiving a score
 **I want** the markdown report to explain how the overall score was calculated
 **So that** I can verify the math, understand pillar weighting, and explain the score to stakeholders
@@ -2379,12 +2380,21 @@ quaid-scanner/
 | Epic 10: Ecosystem Intelligence | 6 | 13 | Rivals, Partners, Communities, Strategy | ✅ Done |
 | Epic 11: Cross-Validation Harness | 4 | 9 | OpenSSF, licensee, accuracy regression CI | 📋 Planned |
 | Epic 12: Ground-Truth Corpus | 4 | 10 | Fixture factory, synthetic repos, mutation tests | 📋 Planned |
-| Epic 13: Trust & Evidence | 4 | 11 | referenceUrl, dataSource, score rationale | 📋 Planned |
+| Epic 13: Trust & Evidence | 5 | 13 | referenceUrl, dataSource, score rationale, .quaid-scanner-ignore | ✅ Done |
 | **Total** | **72** | **173** | | |
 
 ---
 
 ### Change Log
+
+#### v2.5 Changes (from v2.4)
+
+| Change | Impact |
+|--------|--------|
+| Mark Epic 13 all 4 stories as ✅ Done | #103–#106 merged; dataSource, markdown metadata, referenceUrl, score rationale all shipped |
+| Add Story 13.5: `.quaid-scanner-ignore` | ✅ Done — #113 merged; project-level scan exclusion support, fixes excludePatterns dead code |
+| Epic 13 total: 4 → 5 stories, 11 → 13 pts | Story total: 72 → 73; Points: 173 → 175 |
+| PRD version: v2.4 → v2.5 | v0.1.2 release date updated to 2026-05-30 |
 
 #### v2.4 Changes (from v2.3)
 


### PR DESCRIPTION
## Summary

Final housekeeping before the 0.1.2 npm publish:

- **CHANGELOG**: `[0.1.2]` section updated with all post-#102 work — Epic 13 features (#103–#106) and `.quaid-scanner-ignore` support (#113)
- **PRD v2.5**: Epic 13 all four Trust & Evidence stories marked ✅ Done; Story 13.5 (`.quaid-scanner-ignore`) added and marked ✅ Done; change log entry added
- **`.quaid-scanner-ignore`**: Extended with `coverage/` and `src/scanner/inclusive/term-list.ts` to suppress remaining self-scan false positives from generated HTML reports and the term-definition source file

After this merges, the next step is `npm publish` and a GitHub release.

Closes #115