### PR TITLE
fix: cite Microsoft Style Guide for diminishing-language findings (#152)

### DIFF
--- a/src/scanner/inclusive/diminishing-scanner.ts
+++ b/src/scanner/inclusive/diminishing-scanner.ts
@@ -214,7 +214,7 @@ export class DiminishingLanguageScanner implements Scanner {
               column: match.index + 1,
               context: line.trim(),
               suggestion: dp.suggestion,
-              referenceUrl: 'https://inclusivenaming.org/',
+              referenceUrl: 'https://learn.microsoft.com/en-us/style-guide/word-choice/words-and-terms-to-use-and-avoid',
               dataSource: 'local',
             });
 
@@ -257,7 +257,7 @@ export class DiminishingLanguageScanner implements Scanner {
       file: null,
       line: null,
       column: null,
-      referenceUrl: 'https://inclusivenaming.org/',
+      referenceUrl: 'https://learn.microsoft.com/en-us/style-guide/word-choice/words-and-terms-to-use-and-avoid',
       dataSource: 'local',
       suggestion:
         welcomingScore > 85

--- a/tests/scanner/inclusive/diminishing-scanner.test.ts
+++ b/tests/scanner/inclusive/diminishing-scanner.test.ts
@@ -427,6 +427,32 @@ describe('DiminishingLanguageScanner', () => {
     });
   });
 
+  describe('source attribution (#152)', () => {
+    it('per-match findings cite Microsoft Style Guide, not inclusivenaming.org', async () => {
+      writeFileSync(join(tmpDir, 'README.md'), 'Just run npm install to get started.\n');
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const matchFindings = findings.filter((f) => f.category === 'diminishing-language');
+      expect(matchFindings.length).toBeGreaterThan(0);
+      for (const finding of matchFindings) {
+        expect(finding.referenceUrl).toContain('learn.microsoft.com');
+        expect(finding.referenceUrl).not.toContain('inclusivenaming.org');
+      }
+    });
+
+    it('welcoming-score summary finding cites Microsoft Style Guide, not inclusivenaming.org', async () => {
+      writeFileSync(join(tmpDir, 'README.md'), 'Just run npm install to get started.\n');
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const summary = findings.find((f) => f.category === 'welcoming-score');
+      expect(summary).toBeDefined();
+      expect(summary!.referenceUrl).toContain('learn.microsoft.com');
+      expect(summary!.referenceUrl).not.toContain('inclusivenaming.org');
+    });
+  });
+
   describe('ignore patterns (#122)', () => {
     it('skips files matching config excludePatterns', async () => {
       writeFileSync(join(tmpDir, 'README.md'), 'Just run npm install.\n');


### PR DESCRIPTION
## Summary
Closes #152.
- Per-match and summary `referenceUrl` for diminishing-language findings now point to the Microsoft Writing Style Guide "words to use and avoid" page (the actual authority for adverb-of-assumption guidance) instead of inclusivenaming.org (which covers Category A nomenclature only).

## Test plan
- [x] Red test confirms findings cite Microsoft Style Guide, not inclusivenaming.org
- [x] `npm run test:coverage` green, ≥80%

## Notes
Per-term deep links for individual diminishing patterns are a separate concern tracked in #153.
