### PR TITLE
fix: exclude .claude and .ainative from binary-artifacts scan (#150)

### DIFF
--- a/src/scanner/security/binary-artifacts.ts
+++ b/src/scanner/security/binary-artifacts.ts
@@ -28,7 +28,7 @@ const DEFAULT_ALLOWLIST = new Set([
 ]);
 
 /** Directories to exclude from scanning. */
-const EXCLUDED_DIRS = ['node_modules', 'vendor', '.git', 'dist', 'build'];
+const EXCLUDED_DIRS = ['node_modules', 'vendor', '.git', 'dist', 'build', '.claude', '.ainative'];
 
 /** Known magic byte signatures. */
 const MAGIC_SIGNATURES: Array<{ name: string; bytes: number[] }> = [

--- a/tests/scanner/security/binary-artifacts.test.ts
+++ b/tests/scanner/security/binary-artifacts.test.ts
@@ -251,6 +251,28 @@ describe('BinaryArtifactScanner', () => {
     });
   });
 
+  describe('agent tooling directory exclusion', () => {
+    it('excludes .pyc files under .claude/worktrees/ from findings', async () => {
+      writeFixture(tmpDir, '.claude/worktrees/agent-xxx/sub/__pycache__/mod.pyc', Buffer.alloc(50));
+      const findings = await scanner.run(createContext(tmpDir));
+      expect(findings.some((f) => f.file?.includes('.claude'))).toBe(false);
+    });
+
+    it('excludes .pyc files under .ainative/ from findings', async () => {
+      writeFixture(tmpDir, '.ainative/sub/__pycache__/mod.pyc', Buffer.alloc(50));
+      const findings = await scanner.run(createContext(tmpDir));
+      expect(findings.some((f) => f.file?.includes('.ainative'))).toBe(false);
+    });
+
+    it('still detects real binaries at the repo root when agent dirs are excluded', async () => {
+      writeFixture(tmpDir, '.claude/worktrees/agent-xxx/cache.pyc', Buffer.alloc(50));
+      writeFixture(tmpDir, '.ainative/cache.pyc', Buffer.alloc(50));
+      writeFixture(tmpDir, 'real.pyc', Buffer.alloc(50));
+      const findings = await scanner.run(createContext(tmpDir));
+      expect(findings.some((f) => f.file === 'real.pyc')).toBe(true);
+    });
+  });
+
   describe('finding structure', () => {
     it('creates findings with all required fields', async () => {
       writeFixture(tmpDir, 'test.exe', Buffer.alloc(50));


### PR DESCRIPTION
## Summary
Closes #150.
- Adds `.claude` and `.ainative` to `EXCLUDED_DIRS` so agent-worktree caches and ainative tooling caches no longer surface as binary-artifact findings.

## Test plan
- [x] Red test reproduces the bug (tests/scanner/security/binary-artifacts.test.ts)
- [x] `npm run test:coverage` green, ≥80%
- [x] Real binary at repo root still detected
