### PR TITLE
fix: acronym detector skips emphasis words and HTTP verbs (#151)

### DIFF
--- a/src/scanner/inclusive/assumed-knowledge-scanner.ts
+++ b/src/scanner/inclusive/assumed-knowledge-scanner.ts
@@ -46,6 +46,27 @@ const KNOWN_ACRONYMS = new Set<string>([
   'CD', 'PR', 'NPM', 'MIT',
 ]);
 
+/**
+ * Common English/Markdown emphasis words and HTTP verbs that look like
+ * acronyms but are not undefined technical terms. These are excluded from
+ * the undefined-acronym detector to prevent false positives (#151).
+ */
+const EMPHASIS_WORD_DENYLIST = new Set<string>([
+  // Markdown callout / emphasis tokens
+  'WARNING', 'WARNINGS', 'ERROR', 'ERRORS', 'IMPORTANT', 'NOTE', 'NOTES',
+  'TIP', 'TIPS',
+  // Code comment markers
+  'TODO', 'FIXME', 'XXX', 'HACK',
+  // Common documentation file names used inline
+  'README', 'CHANGELOG', 'LICENSE', 'AUTHORS', 'COPYING',
+  // Status / requirement adjectives
+  'ESTABLISHED', 'REQUIRED', 'OPTIONAL', 'DEPRECATED', 'OBSOLETE',
+  // Boolean / null literals
+  'TRUE', 'FALSE', 'NULL', 'NONE', 'YES', 'NO',
+  // HTTP verbs — common vocabulary in API docs, not undefined acronyms
+  'GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS', 'TRACE',
+]);
+
 /** Pattern to match prerequisite/requirements section headings. */
 const PREREQUISITES_HEADING = /^#{1,3}\s+(prerequisites|requirements)\s*$/im;
 
@@ -195,6 +216,11 @@ export class AssumedKnowledgeScanner implements Scanner {
 
         // Skip known acronyms
         if (KNOWN_ACRONYMS.has(acronym)) {
+          continue;
+        }
+
+        // Skip common emphasis words and HTTP verbs — not undefined acronyms
+        if (EMPHASIS_WORD_DENYLIST.has(acronym)) {
           continue;
         }
 

--- a/tests/scanner/inclusive/assumed-knowledge-scanner.test.ts
+++ b/tests/scanner/inclusive/assumed-knowledge-scanner.test.ts
@@ -346,6 +346,159 @@ describe('AssumedKnowledgeScanner', () => {
     });
   });
 
+  describe('emphasis word denylist (#151)', () => {
+    it('does NOT flag "WARNING" in a markdown line', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'README.md'),
+        '# Project\n\n**WARNING**: This is an important notice.\n',
+      );
+
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const warningFinding = findings.find(
+        (f) => f.category === 'undefined-acronym' && f.message.includes('WARNING'),
+      );
+      expect(warningFinding).toBeUndefined();
+    });
+
+    it('does NOT flag "WARNINGS" in documentation text', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'README.md'),
+        '# Project\n\nCheck the WARNINGS section for details.\n',
+      );
+
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const warningsFinding = findings.find(
+        (f) => f.category === 'undefined-acronym' && f.message.includes('WARNINGS'),
+      );
+      expect(warningsFinding).toBeUndefined();
+    });
+
+    it('does NOT flag "TODO" in documentation text', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'README.md'),
+        '# Project\n\nTODO: add more documentation here.\n',
+      );
+
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const todoFinding = findings.find(
+        (f) => f.category === 'undefined-acronym' && f.message.includes('TODO'),
+      );
+      expect(todoFinding).toBeUndefined();
+    });
+
+    it('does NOT flag "FIXME" in documentation text', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'README.md'),
+        '# Project\n\nFIXME: this section is incomplete.\n',
+      );
+
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const fixmeFinding = findings.find(
+        (f) => f.category === 'undefined-acronym' && f.message.includes('FIXME'),
+      );
+      expect(fixmeFinding).toBeUndefined();
+    });
+
+    it('does NOT flag "README" in documentation text', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'README.md'),
+        '# Project\n\nSee the README for more details.\n',
+      );
+
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const readmeFinding = findings.find(
+        (f) => f.category === 'undefined-acronym' && f.message.includes('README'),
+      );
+      expect(readmeFinding).toBeUndefined();
+    });
+
+    it('does NOT flag HTTP verb "GET" in API documentation', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'README.md'),
+        '# Project\n\nSend a GET request to retrieve data from the endpoint.\n',
+      );
+
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const getFinding = findings.find(
+        (f) => f.category === 'undefined-acronym' && f.message.includes('"GET"'),
+      );
+      expect(getFinding).toBeUndefined();
+    });
+
+    it('does NOT flag HTTP verb "POST" in API documentation', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'README.md'),
+        '# Project\n\nSend a POST request to create a new resource.\n',
+      );
+
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const postFinding = findings.find(
+        (f) => f.category === 'undefined-acronym' && f.message.includes('"POST"'),
+      );
+      expect(postFinding).toBeUndefined();
+    });
+
+    it('does NOT flag HTTP verb "PUT" in API documentation', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'README.md'),
+        '# Project\n\nSend a PUT request to update the resource.\n',
+      );
+
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const putFinding = findings.find(
+        (f) => f.category === 'undefined-acronym' && f.message.includes('"PUT"'),
+      );
+      expect(putFinding).toBeUndefined();
+    });
+
+    it('does NOT flag HTTP verb "DELETE" in API documentation', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'README.md'),
+        '# Project\n\nSend a DELETE request to remove the resource.\n',
+      );
+
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const deleteFinding = findings.find(
+        (f) => f.category === 'undefined-acronym' && f.message.includes('"DELETE"'),
+      );
+      expect(deleteFinding).toBeUndefined();
+    });
+
+    it('DOES still flag a real undefined acronym like "RBAC"', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'README.md'),
+        '# Project\n\nThis project uses RBAC for access control.\n',
+      );
+
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const rbacFinding = findings.find(
+        (f) => f.category === 'undefined-acronym' && f.message.includes('RBAC'),
+      );
+      expect(rbacFinding).toBeDefined();
+      expect(rbacFinding!.severity).toBe(Severity.INFO);
+    });
+  });
+
   describe('ignore patterns (#122)', () => {
     it('skips files matching config excludePatterns', async () => {
       fs.writeFileSync(


### PR DESCRIPTION
## Summary
Closes #151.
- Adds a denylist of common emphasis tokens (WARNING, TODO, README, IMPORTANT, ERRORS, etc.) and HTTP verbs (GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS, TRACE) to the undefined-acronym detector so they no longer surface as false positives.

## Test plan
- [x] Red tests confirm emphasis words (WARNING, WARNINGS, TODO, FIXME, README) are not flagged
- [x] Red tests confirm HTTP verbs (GET, POST, PUT, DELETE) are not flagged
- [x] Real undefined acronyms (RBAC) still flagged as expected
- [x] `npm run test:coverage` green (30/30 on assumed-knowledge-scanner, 1518/1530 suite — 12 pre-existing subprocess failures unrelated to this change)

## Notes
Denylist-based fix only; richer emphasis-context detection (markdown bold/italic surroundings, ATX headings) is a possible follow-up if false positives recur.
