### PR TITLE
fix: split scanner errors into separate report section (#154)

### DIFF
--- a/src/reporters/markdown.ts
+++ b/src/reporters/markdown.ts
@@ -1,5 +1,6 @@
 import { Severity, Pillar, RiskLevel, PILLAR_WEIGHTS } from '../types/index.js';
 import type { ScanReport, Finding, FindingDataSource } from '../types/index.js';
+import { isErrorFinding } from '../issues.js';
 
 const PILLAR_LABELS: Record<Pillar, string> = {
   [Pillar.SECURITY]: 'Security',
@@ -118,10 +119,13 @@ export function renderMarkdown(report: ScanReport, options?: MarkdownReportOptio
   }
   lines.push('');
 
-  // Findings grouped by severity
-  const criticals = findingsBySeverity(report.findings, Severity.CRITICAL);
-  const warnings = findingsBySeverity(report.findings, Severity.WARNING);
-  const infos = findingsBySeverity(report.findings, Severity.INFO);
+  // Findings grouped by severity — scanner-failure findings are separated out
+  const allWarnings = findingsBySeverity(report.findings, Severity.WARNING);
+  const realWarnings = allWarnings.filter((f) => !isErrorFinding(f));
+  const scannerErrorFindings = allWarnings.filter(isErrorFinding);
+
+  const criticals = findingsBySeverity(report.findings, Severity.CRITICAL).filter((f) => !isErrorFinding(f));
+  const infos = findingsBySeverity(report.findings, Severity.INFO).filter((f) => !isErrorFinding(f));
 
   if (criticals.length > 0) {
     lines.push('## Critical Findings');
@@ -146,11 +150,32 @@ export function renderMarkdown(report: ScanReport, options?: MarkdownReportOptio
     }
   }
 
-  if (warnings.length > 0) {
+  if (realWarnings.length > 0) {
     lines.push('## Warnings');
     lines.push('');
-    for (const f of warnings) {
+    for (const f of realWarnings) {
       lines.push(`- **[${f.id}]** ${f.message} *(${f.suggestion})*`);
+    }
+    lines.push('');
+  }
+
+  // Scanner Errors section: shown when the report is partial OR when scanner-failure
+  // findings were collected. Prefers report.failedScanners[] (orchestrator canonical list)
+  // when non-empty; otherwise derives the list from filtered findings.
+  const showScannerErrors = report.partial || scannerErrorFindings.length > 0;
+  if (showScannerErrors) {
+    lines.push('## Scanner Errors');
+    lines.push('');
+    lines.push('_One or more scanners did not complete successfully. Findings below reflect scanner reliability issues, not repo health._');
+    lines.push('');
+    if (report.failedScanners != null && report.failedScanners.length > 0) {
+      for (const fs of report.failedScanners) {
+        lines.push(`- **[${fs.name}]** *(${fs.reason})* ${fs.pillar} — ${fs.message}`);
+      }
+    } else {
+      for (const f of scannerErrorFindings) {
+        lines.push(`- **[${f.id}]** *(${f.category})* ${f.pillar} — ${f.message}`);
+      }
     }
     lines.push('');
   }

--- a/tests/reporters/markdown.test.ts
+++ b/tests/reporters/markdown.test.ts
@@ -852,4 +852,93 @@ describe('renderMarkdown', () => {
     const md = renderMarkdown(makeReport());
     expect(md).toContain('| Pillar | Weight | Raw Score | Contribution |');
   });
+
+  // --- scanner errors section (issue #154) ---
+
+  describe('scanner errors section (#154)', () => {
+    it('puts timeout finding under ## Scanner Errors and real warning under ## Warnings, not under ## Scanner Errors', () => {
+      const findings: Finding[] = [
+        {
+          id: 'gov-01',
+          severity: Severity.WARNING,
+          pillar: Pillar.GOVERNANCE,
+          category: 'license',
+          message: 'No license file found',
+          file: null,
+          line: null,
+          column: null,
+          suggestion: 'Add a LICENSE file',
+        },
+        {
+          id: 'scanner-timeout-01',
+          severity: Severity.WARNING,
+          pillar: Pillar.SECURITY,
+          category: 'timeout',
+          message: 'scorecard scanner timed out after 30s',
+          file: null,
+          line: null,
+          column: null,
+          suggestion: 'Increase scanner timeout or check network',
+        },
+      ];
+      const report = makeReport(findings);
+      const md = renderMarkdown(report);
+
+      // Scanner Errors section must exist and contain the timeout finding message
+      expect(md).toContain('## Scanner Errors');
+      expect(md).toContain('scorecard scanner timed out after 30s');
+
+      // The real warning must appear in the ## Warnings section
+      expect(md).toContain('## Warnings');
+      expect(md).toContain('No license file found');
+
+      // The timeout finding message must NOT appear in the ## Warnings section
+      const warnStart = md.indexOf('## Warnings');
+      const errStart = md.indexOf('## Scanner Errors');
+      // ## Warnings appears before ## Scanner Errors
+      expect(warnStart).toBeLessThan(errStart);
+      const warnSection = md.slice(warnStart, errStart);
+      expect(warnSection).not.toContain('scorecard scanner timed out after 30s');
+    });
+
+    it('does not render ## Scanner Errors section when partial is false and there are no error/timeout findings', () => {
+      const findings: Finding[] = [
+        {
+          id: 'gov-01',
+          severity: Severity.WARNING,
+          pillar: Pillar.GOVERNANCE,
+          category: 'license',
+          message: 'No license file found',
+          file: null,
+          line: null,
+          column: null,
+          suggestion: 'Add a LICENSE file',
+        },
+      ];
+      const report = makeReport(findings);
+      // Ensure partial is false
+      const nonPartialReport: ScanReport = { ...report, partial: false, failedScanners: [] };
+      const md = renderMarkdown(nonPartialReport);
+      expect(md).not.toContain('## Scanner Errors');
+    });
+
+    it('shows scanner name from failedScanners in ## Scanner Errors section when partial is true', () => {
+      const report = makeReport([]);
+      const partialReport: ScanReport = {
+        ...report,
+        partial: true,
+        failedScanners: [
+          {
+            name: 'scorecard',
+            pillar: 'security',
+            reason: 'timeout',
+            message: 'scorecard timed out after 30s',
+          },
+        ],
+      };
+      const md = renderMarkdown(partialReport);
+      expect(md).toContain('## Scanner Errors');
+      expect(md).toContain('scorecard');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Closes #154.
- Scanner-failure findings (category `timeout`/`error`) now render in a dedicated `## Scanner Errors` section instead of being mixed into `## Warnings`, so report readers can distinguish real repo warnings from scanner reliability issues.
- Uses `isErrorFinding` (already exported in v0.1.3) and prefers `report.failedScanners[]` as the canonical list when populated.

## Test plan
- [x] Red tests confirm the split
- [x] `npm run test:coverage` green, ≥80%
