### PR TITLE
feat: per-term referenceUrl on diminishing patterns (#153)

### DIFF
--- a/src/scanner/inclusive/diminishing-scanner.ts
+++ b/src/scanner/inclusive/diminishing-scanner.ts
@@ -21,6 +21,7 @@ interface DiminishingPattern {
   pattern: RegExp;
   severity: Severity;
   suggestion: string;
+  referenceUrl: string;
 }
 
 /** All diminishing language patterns to detect. */
@@ -31,6 +32,8 @@ const DIMINISHING_PATTERNS: DiminishingPattern[] = [
     severity: Severity.WARNING,
     suggestion:
       'Remove "just" — it implies the task is trivial and can discourage readers who find it difficult.',
+    referenceUrl:
+      'https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/j/just',
   },
   {
     name: 'simply [verb]',
@@ -38,6 +41,8 @@ const DIMINISHING_PATTERNS: DiminishingPattern[] = [
     severity: Severity.WARNING,
     suggestion:
       'Remove "simply" — it implies the task should be obvious and can make readers feel inadequate.',
+    referenceUrl:
+      'https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/s/simply',
   },
   {
     name: 'easy/easily',
@@ -45,6 +50,8 @@ const DIMINISHING_PATTERNS: DiminishingPattern[] = [
     severity: Severity.INFO,
     suggestion:
       'Consider removing "easy/easily" — what is easy for one person may be challenging for another.',
+    referenceUrl:
+      'https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/e/easy-easily',
   },
   {
     name: 'obvious/obviously',
@@ -52,6 +59,8 @@ const DIMINISHING_PATTERNS: DiminishingPattern[] = [
     severity: Severity.WARNING,
     suggestion:
       'Remove "obvious/obviously" — if it were truly obvious, it would not need to be stated.',
+    referenceUrl:
+      'https://learn.microsoft.com/en-us/style-guide/word-choice/words-and-terms-to-use-and-avoid',
   },
   {
     name: 'trivial',
@@ -59,6 +68,7 @@ const DIMINISHING_PATTERNS: DiminishingPattern[] = [
     severity: Severity.INFO,
     suggestion:
       'Consider replacing "trivial" with specific guidance about the expected effort level.',
+    referenceUrl: 'https://www.plainlanguage.gov/guidelines/words/avoid-jargon/',
   },
   {
     name: 'everyone knows',
@@ -66,6 +76,7 @@ const DIMINISHING_PATTERNS: DiminishingPattern[] = [
     severity: Severity.WARNING,
     suggestion:
       'Remove "everyone knows" — not everyone has the same knowledge. Explain the concept instead.',
+    referenceUrl: 'https://content-guide.18f.gov/our-style/inclusive-language/',
   },
   {
     name: 'as you know',
@@ -73,6 +84,7 @@ const DIMINISHING_PATTERNS: DiminishingPattern[] = [
     severity: Severity.WARNING,
     suggestion:
       'Remove "as you know" — readers may not know. State the information directly.',
+    referenceUrl: 'https://content-guide.18f.gov/our-style/inclusive-language/',
   },
   {
     name: 'of course',
@@ -80,6 +92,8 @@ const DIMINISHING_PATTERNS: DiminishingPattern[] = [
     severity: Severity.INFO,
     suggestion:
       'Consider removing "of course" — it assumes shared knowledge that newcomers may lack.',
+    referenceUrl:
+      'https://learn.microsoft.com/en-us/style-guide/word-choice/words-and-terms-to-use-and-avoid',
   },
   {
     name: 'clearly',
@@ -87,6 +101,8 @@ const DIMINISHING_PATTERNS: DiminishingPattern[] = [
     severity: Severity.INFO,
     suggestion:
       'Consider removing "clearly" — if it is clear, the reader will see it without being told.',
+    referenceUrl:
+      'https://learn.microsoft.com/en-us/style-guide/word-choice/words-and-terms-to-use-and-avoid',
   },
   {
     name: 'basically',
@@ -94,6 +110,8 @@ const DIMINISHING_PATTERNS: DiminishingPattern[] = [
     severity: Severity.INFO,
     suggestion:
       'Consider removing "basically" — provide the actual explanation instead of a simplification signal.',
+    referenceUrl:
+      'https://learn.microsoft.com/en-us/style-guide/word-choice/words-and-terms-to-use-and-avoid',
   },
 ];
 
@@ -214,7 +232,7 @@ export class DiminishingLanguageScanner implements Scanner {
               column: match.index + 1,
               context: line.trim(),
               suggestion: dp.suggestion,
-              referenceUrl: 'https://learn.microsoft.com/en-us/style-guide/word-choice/words-and-terms-to-use-and-avoid',
+              referenceUrl: dp.referenceUrl,
               dataSource: 'local',
             });
 

--- a/tests/scanner/inclusive/diminishing-scanner.test.ts
+++ b/tests/scanner/inclusive/diminishing-scanner.test.ts
@@ -453,6 +453,80 @@ describe('DiminishingLanguageScanner', () => {
     });
   });
 
+  describe('per-term referenceUrl (#153)', () => {
+    it('finding for "just run" has referenceUrl containing /j/just', async () => {
+      writeFileSync(join(tmpDir, 'README.md'), 'Just run npm install.\n');
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const match = findings.find(
+        (f) => f.category === 'diminishing-language' && f.message.includes('just run'),
+      );
+      expect(match).toBeDefined();
+      expect(match!.referenceUrl).toContain('/j/just');
+    });
+
+    it('finding for "simply add" has referenceUrl containing /s/simply', async () => {
+      writeFileSync(join(tmpDir, 'CONTRIBUTING.md'), 'You simply add the dependency.\n');
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const match = findings.find(
+        (f) => f.category === 'diminishing-language' && f.message.includes('simply add'),
+      );
+      expect(match).toBeDefined();
+      expect(match!.referenceUrl).toContain('/s/simply');
+    });
+
+    it('finding for "easy" has referenceUrl containing /e/easy-easily', async () => {
+      writeFileSync(join(tmpDir, 'README.md'), 'This is an easy setup process.\n');
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const match = findings.find(
+        (f) => f.category === 'diminishing-language' && f.message.includes('easy'),
+      );
+      expect(match).toBeDefined();
+      expect(match!.referenceUrl).toContain('/e/easy-easily');
+    });
+
+    it('finding for "trivial" has referenceUrl containing plainlanguage.gov', async () => {
+      writeFileSync(join(tmpDir, 'README.md'), 'The fix is trivial to implement.\n');
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const match = findings.find(
+        (f) => f.category === 'diminishing-language' && f.message.includes('trivial'),
+      );
+      expect(match).toBeDefined();
+      expect(match!.referenceUrl).toContain('plainlanguage.gov');
+    });
+
+    it('finding for "everyone knows" has referenceUrl containing content-guide.18f.gov', async () => {
+      writeFileSync(join(tmpDir, 'README.md'), 'Everyone knows how to use git.\n');
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const match = findings.find(
+        (f) => f.category === 'diminishing-language' && f.message.includes('everyone knows'),
+      );
+      expect(match).toBeDefined();
+      expect(match!.referenceUrl).toContain('content-guide.18f.gov');
+    });
+
+    it('summary welcoming-score referenceUrl is unchanged (generic Microsoft URL)', async () => {
+      writeFileSync(join(tmpDir, 'README.md'), 'Just run npm install.\n');
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const summary = findings.find((f) => f.category === 'welcoming-score');
+      expect(summary).toBeDefined();
+      expect(summary!.referenceUrl).toBe(
+        'https://learn.microsoft.com/en-us/style-guide/word-choice/words-and-terms-to-use-and-avoid',
+      );
+    });
+  });
+
   describe('ignore patterns (#122)', () => {
     it('skips files matching config excludePatterns', async () => {
       writeFileSync(join(tmpDir, 'README.md'), 'Just run npm install.\n');


### PR DESCRIPTION
## Summary
Closes #153.
- Adds `referenceUrl` to the `DiminishingPattern` interface and populates one authoritative URL per term so per-match findings now deep-link to the specific guidance (Microsoft Style Guide A-Z entries for "just", "simply", "easy/easily"; plainlanguage.gov for "trivial"; 18F for "everyone knows" / "as you know").
- The summary `welcoming-score` finding's `referenceUrl` is unchanged.

## Test plan
- [x] Red tests confirm per-term URLs (just, simply, easy, trivial, everyone knows)
- [x] Summary finding still uses the generic Microsoft URL
- [x] `npm run test:coverage` green, >=80%
