### PR TITLE
feat: decouple INI tier from severity; cap inclusive at WARNING (#165)

### DIFF
--- a/docs/PRD-v2.md
+++ b/docs/PRD-v2.md
@@ -1419,7 +1419,7 @@ model-index:
 | 6.1c.3 | Allow per-line suppression with comment `// inclusive-naming-ignore` or `# inclusive-naming-ignore` | Suppression support |
 | 6.1c.4 | Config option `inclusive.ignore_terms: ["master"]` to skip specific terms | Config support |
 
-**Tier 1 - Replace Immediately (CRITICAL):**
+**Tier 1 - Replace Immediately:**
 
 | Term | Regex Pattern | Replacements |
 |------|---------------|--------------|
@@ -1449,7 +1449,7 @@ model-index:
 |---|-----------|--------------|
 | 6.1d.1 | Group findings by tier with severity mapping | Tier aggregation |
 | 6.1d.2 | Calculate score: 100 - (tier1 × 10 + tier2 × 5 + tier3 × 2) capped at 0 | Score formula |
-| 6.1d.3 | CRITICAL if score < 50 | Threshold check |
+| 6.1d.3 | WARNING if score < 50 (inclusive scanners cap at WARNING; CRITICAL is reserved for harm-class findings) | Threshold check |
 | 6.1d.4 | WARNING if score 50-80 | Threshold check |
 | 6.1d.5 | PASS if score > 80 | Threshold check |
 
@@ -1488,7 +1488,7 @@ model-index:
 | 6.1e.1 | Check `package.json` `name` field against all loaded INI terms | Tests pass |
 | 6.1e.2 | Check README.md first H1 line against all loaded INI terms | Tests pass |
 | 6.1e.3 | Check git remote slug (last URL path segment) against all loaded INI terms | Tests pass |
-| 6.1e.4 | Severity: CRITICAL (tier 1), WARNING (tier 2), INFO (tier 3) | Severity mapping correct |
+| 6.1e.4 | Severity: WARNING (tier 1), WARNING (tier 2), INFO (tier 3); INI tier surfaced as `[Tier N — label]` prefix in reports (#165) | Severity mapping correct |
 | 6.1e.5 | `suggestion` field includes recommended rename path and INI replacements | Suggestion present |
 | 6.1e.6 | Graceful degradation when `package.json` missing or malformed | INFO finding, no throw |
 
@@ -1516,7 +1516,7 @@ model-index:
 | 6.2.7 | Group findings by file with counts | Aggregation |
 | 6.2.8 | PASS if welcoming score > 85 | Threshold check |
 | 6.2.9 | WARNING if score 60-85 | Threshold check |
-| 6.2.10 | CRITICAL if score < 60 | Threshold check |
+| 6.2.10 | WARNING if score < 60 (inclusive scanners cap at WARNING; CRITICAL reserved for harm-class findings) | Threshold check |
 
 **Diminishing Language Patterns:**
 
@@ -1636,6 +1636,26 @@ captured as a future story.
 - Write the Docs Style Guides — https://www.writethedocs.org/guide/writing/style-guides/
 - Alex.js — https://alexjs.com/
 - Vale — https://vale.sh/
+
+#### Severity Model Decision Record (v0.1.4 — #165)
+
+**Decision:** `Severity.CRITICAL` is reserved for harm-class findings across all pillars —
+security vulnerabilities, legal exposure, and operational failures that, if ignored, cause
+direct risk to the project or its users. Inclusive-language findings do not meet this bar.
+
+**INI tier and severity are separate axes:**
+
+| Axis | What it expresses | Values |
+|------|------------------|--------|
+| **Severity** | Risk/impact if the finding is ignored | CRITICAL (harm-class) · WARNING · INFO · PASS |
+| **INI Tier** | Replacement urgency per the Inclusive Naming Initiative | Tier 1 — Replace Immediately · Tier 2 — Strongly Consider · Tier 3 — Recommended |
+
+**Effect on scanners (effective v0.1.4):**
+- `naming-scanner.ts`: `tierToSeverity` maps Tier 1 and Tier 2 → `WARNING`; Tier 3 → `INFO`.
+- `diminishing-scanner.ts`: welcoming-score summary caps at `WARNING` (sub-60 scores no longer produce `CRITICAL`).
+- INI tier is surfaced as a first-class label in markdown reports: `[Tier N — Replace Immediately / Strongly Consider / Recommended]` prefix on any finding with `metadata.tier`.
+
+**Not in scope for this decision:** `doc-scanner.ts`, `code-scanner.ts`, and `scoring.ts` retain their current tier→severity mappings; they are addressed separately in a future story.
 
 ---
 

--- a/src/reporters/markdown.ts
+++ b/src/reporters/markdown.ts
@@ -76,6 +76,26 @@ function renderFindingExtras(f: Finding): string[] {
     return lines;
 }
 
+const INI_TIER_LABELS: Record<1 | 2 | 3, string> = {
+  1: 'Replace Immediately',
+  2: 'Strongly Consider',
+  3: 'Recommended',
+};
+
+/**
+ * Return the INI tier prefix string for a finding that has `metadata.tier` set,
+ * or an empty string for findings without tier metadata.
+ *
+ * Format: `[Tier N — <label>] `
+ */
+function tierPrefix(f: Finding): string {
+  const tier = f.metadata?.tier;
+  if (tier === 1 || tier === 2 || tier === 3) {
+    return `[Tier ${tier} — ${INI_TIER_LABELS[tier]}] `;
+  }
+  return '';
+}
+
 export interface MarkdownReportOptions {
   /** Optional ecosystem metadata to include as a dedicated section */
   ecosystem?: {
@@ -154,7 +174,7 @@ export function renderMarkdown(report: ScanReport, options?: MarkdownReportOptio
     lines.push('## Warnings');
     lines.push('');
     for (const f of realWarnings) {
-      lines.push(`- **[${f.id}]** ${f.message} *(${f.suggestion})*`);
+      lines.push(`- **[${f.id}]** ${tierPrefix(f)}${f.message} *(${f.suggestion})*`);
     }
     lines.push('');
   }
@@ -184,7 +204,7 @@ export function renderMarkdown(report: ScanReport, options?: MarkdownReportOptio
     lines.push('## Info');
     lines.push('');
     for (const f of infos) {
-      lines.push(`- **[${f.id}]** ${f.message}`);
+      lines.push(`- **[${f.id}]** ${tierPrefix(f)}${f.message}`);
     }
     lines.push('');
   }

--- a/src/scanner/inclusive/diminishing-scanner.ts
+++ b/src/scanner/inclusive/diminishing-scanner.ts
@@ -255,14 +255,14 @@ export class DiminishingLanguageScanner implements Scanner {
     // Calculate welcoming score: 100 - (warning_count * 3 + info_count * 1), minimum 0
     const welcomingScore = Math.max(0, 100 - (warningCount * 3 + infoCount * 1));
 
-    // Determine severity based on thresholds
+    // Determine severity based on thresholds.
+    // Inclusive scanners cap at WARNING — CRITICAL is reserved for harm-class
+    // (security/legal/operational) findings. Sub-60 scores produce WARNING (#165).
     let summarySeverity: Severity;
     if (welcomingScore > 85) {
       summarySeverity = Severity.PASS;
-    } else if (welcomingScore >= 60) {
-      summarySeverity = Severity.WARNING;
     } else {
-      summarySeverity = Severity.CRITICAL;
+      summarySeverity = Severity.WARNING;
     }
 
     // Add summary finding

--- a/src/scanner/inclusive/naming-scanner.ts
+++ b/src/scanner/inclusive/naming-scanner.ts
@@ -20,12 +20,16 @@ import { TermListManager, type LoadedTerm } from './term-list.js';
 
 /**
  * Map term tier to finding severity.
- * Tier 1 = CRITICAL, Tier 2 = WARNING, Tier 3 = INFO.
+ * Inclusive scanners cap at WARNING — CRITICAL is reserved for harm-class
+ * (security/legal/operational) findings across all pillars. INI tier expresses
+ * replacement urgency and is surfaced as a tier label in reports (#165).
+ *
+ * Tier 1 → WARNING, Tier 2 → WARNING, Tier 3 → INFO.
  */
 function tierToSeverity(tier: 1 | 2 | 3): Severity {
   switch (tier) {
     case 1:
-      return Severity.CRITICAL;
+      return Severity.WARNING;
     case 2:
       return Severity.WARNING;
     case 3:

--- a/tests/reporters/markdown.test.ts
+++ b/tests/reporters/markdown.test.ts
@@ -853,6 +853,88 @@ describe('renderMarkdown', () => {
     expect(md).toContain('| Pillar | Weight | Raw Score | Contribution |');
   });
 
+  // --- INI tier label rendering (#165) ---
+
+  describe('INI tier label (#165)', () => {
+    it('prefixes warning finding line with "[Tier 1 — Replace Immediately]" when metadata.tier is 1', () => {
+      const findings: Finding[] = [
+        {
+          id: 'ini-tier-01',
+          severity: Severity.WARNING,
+          pillar: Pillar.INCLUSIVE,
+          category: 'inclusive-naming',
+          message: 'Project name contains non-inclusive term "whitelist"',
+          file: 'package.json',
+          line: null,
+          column: null,
+          suggestion: 'Rename using allowlist',
+          metadata: { tier: 1, term: 'whitelist', replacements: ['allowlist'] },
+        },
+      ];
+      const md = renderMarkdown(makeReport(findings));
+      expect(md).toContain('Tier 1');
+      expect(md).toContain('Replace Immediately');
+    });
+
+    it('prefixes warning finding line with "[Tier 2 — Strongly Consider]" when metadata.tier is 2', () => {
+      const findings: Finding[] = [
+        {
+          id: 'ini-tier-02',
+          severity: Severity.WARNING,
+          pillar: Pillar.INCLUSIVE,
+          category: 'inclusive-naming',
+          message: 'Project name contains non-inclusive term "blacklist"',
+          file: null,
+          line: null,
+          column: null,
+          suggestion: 'Rename using blocklist',
+          metadata: { tier: 2, term: 'blacklist', replacements: ['blocklist'] },
+        },
+      ];
+      const md = renderMarkdown(makeReport(findings));
+      expect(md).toContain('Tier 2');
+      expect(md).toContain('Strongly Consider');
+    });
+
+    it('prefixes info finding line with "[Tier 3 — Recommended]" when metadata.tier is 3', () => {
+      const findings: Finding[] = [
+        {
+          id: 'ini-tier-03',
+          severity: Severity.INFO,
+          pillar: Pillar.INCLUSIVE,
+          category: 'inclusive-naming',
+          message: 'Project name contains non-inclusive term "master"',
+          file: null,
+          line: null,
+          column: null,
+          suggestion: 'Rename using main',
+          metadata: { tier: 3, term: 'master', replacements: ['main'] },
+        },
+      ];
+      const md = renderMarkdown(makeReport(findings));
+      expect(md).toContain('Tier 3');
+      expect(md).toContain('Recommended');
+    });
+
+    it('does not add tier prefix to findings without metadata.tier', () => {
+      const findings: Finding[] = [
+        {
+          id: 'gov-no-tier',
+          severity: Severity.WARNING,
+          pillar: Pillar.GOVERNANCE,
+          category: 'license',
+          message: 'No license file found',
+          file: null,
+          line: null,
+          column: null,
+          suggestion: 'Add a LICENSE file',
+        },
+      ];
+      const md = renderMarkdown(makeReport(findings));
+      expect(md).not.toContain('[Tier');
+    });
+  });
+
   // --- scanner errors section (issue #154) ---
 
   describe('scanner errors section (#154)', () => {

--- a/tests/scanner/inclusive/diminishing-scanner.test.ts
+++ b/tests/scanner/inclusive/diminishing-scanner.test.ts
@@ -305,8 +305,9 @@ describe('DiminishingLanguageScanner', () => {
       expect(score).toBeLessThanOrEqual(85);
     });
 
-    it('returns CRITICAL finding when welcoming score < 60', async () => {
+    it('returns WARNING finding when welcoming score < 60', async () => {
       // Need enough issues: 14 WARNINGs = 42 deducted => score 58
+      // Inclusive scanners are capped at WARNING — no CRITICAL emitted (#165)
       const lines = [
         'Just run this command.',
         'Just do this step.',
@@ -329,7 +330,8 @@ describe('DiminishingLanguageScanner', () => {
 
       const summary = findings.find((f) => f.category === 'welcoming-score');
       expect(summary).toBeDefined();
-      expect(summary!.severity).toBe(Severity.CRITICAL);
+      expect(summary!.severity).toBe(Severity.WARNING);
+      expect(summary!.severity).not.toBe(Severity.CRITICAL);
       const score = summary!.metadata?.welcomingScore as number;
       expect(score).toBeLessThan(60);
     });
@@ -524,6 +526,19 @@ describe('DiminishingLanguageScanner', () => {
       expect(summary!.referenceUrl).toBe(
         'https://learn.microsoft.com/en-us/style-guide/word-choice/words-and-terms-to-use-and-avoid',
       );
+    });
+  });
+
+  describe('severity ceiling (#165)', () => {
+    it('never emits a CRITICAL finding regardless of score', async () => {
+      // Saturate with diminishing language — score should drop well below 60
+      const lines = Array.from({ length: 20 }, (_, i) => `Just run step ${i + 1}.`);
+      writeFileSync(join(tmpDir, 'README.md'), lines.join('\n') + '\n');
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const criticalFindings = findings.filter((f) => f.severity === Severity.CRITICAL);
+      expect(criticalFindings).toHaveLength(0);
     });
   });
 

--- a/tests/scanner/inclusive/naming-scanner.test.ts
+++ b/tests/scanner/inclusive/naming-scanner.test.ts
@@ -690,4 +690,95 @@ describe('NamingScanner', () => {
       expect(findings.length).toBeGreaterThan(0);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Severity capping (#165): CRITICAL is never emitted by inclusive scanners
+  // -------------------------------------------------------------------------
+
+  describe('severity capping (#165)', () => {
+    it('maps Tier 1 term to WARNING (not CRITICAL)', async () => {
+      const scanner = setupScanner([WHITELIST_TERM]);
+      (fs.existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: unknown) =>
+        (p as string).endsWith('package.json')
+      );
+      (fs.readFileSync as ReturnType<typeof vi.fn>).mockImplementation((p: unknown) => {
+        if ((p as string).endsWith('package.json')) {
+          return JSON.stringify({ name: 'whitelist-manager' });
+        }
+        return '';
+      });
+
+      const findings = await scanner.run(createContext());
+
+      const finding = findings.find((f) => f.file === 'package.json');
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe(Severity.WARNING);
+      expect(finding!.severity).not.toBe(Severity.CRITICAL);
+    });
+
+    it('maps Tier 2 term to WARNING', async () => {
+      const scanner = setupScanner([BLACKLIST_TERM]);
+      (fs.existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: unknown) =>
+        (p as string).endsWith('package.json')
+      );
+      (fs.readFileSync as ReturnType<typeof vi.fn>).mockImplementation((p: unknown) => {
+        if ((p as string).endsWith('package.json')) {
+          return JSON.stringify({ name: 'blacklist-checker' });
+        }
+        return '';
+      });
+
+      const findings = await scanner.run(createContext());
+
+      const finding = findings.find((f) => f.file === 'package.json');
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe(Severity.WARNING);
+    });
+
+    it('maps Tier 3 term to INFO', async () => {
+      const scanner = setupScanner([MASTER_TERM]);
+      (fs.existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: unknown) =>
+        (p as string).endsWith('package.json')
+      );
+      (fs.readFileSync as ReturnType<typeof vi.fn>).mockImplementation((p: unknown) => {
+        if ((p as string).endsWith('package.json')) {
+          return JSON.stringify({ name: 'master-config' });
+        }
+        return '';
+      });
+
+      const findings = await scanner.run(createContext());
+
+      const finding = findings.find((f) => f.file === 'package.json');
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe(Severity.INFO);
+    });
+
+    it('never emits CRITICAL from any source', async () => {
+      const scanner = setupScanner([WHITELIST_TERM]);
+      (fs.existsSync as ReturnType<typeof vi.fn>).mockImplementation(
+        (p: unknown) =>
+          (p as string).endsWith('package.json') || (p as string).endsWith('README.md')
+      );
+      (fs.readFileSync as ReturnType<typeof vi.fn>).mockImplementation((p: unknown) => {
+        if ((p as string).endsWith('package.json')) {
+          return JSON.stringify({ name: 'whitelist-tool' });
+        }
+        if ((p as string).endsWith('README.md')) {
+          return '# Whitelist Tool\n';
+        }
+        return '';
+      });
+      (childProcess.spawnSync as ReturnType<typeof vi.fn>).mockReturnValue({
+        status: 0,
+        stdout: Buffer.from('https://github.com/org/whitelist-service.git\n'),
+        stderr: Buffer.from(''),
+      });
+
+      const findings = await scanner.run(createContext());
+
+      const criticalFindings = findings.filter((f) => f.severity === Severity.CRITICAL);
+      expect(criticalFindings).toHaveLength(0);
+    });
+  });
 });

--- a/tests/scanner/inclusive/naming-scanner.test.ts
+++ b/tests/scanner/inclusive/naming-scanner.test.ts
@@ -39,7 +39,7 @@ import { NamingScanner } from '../../../src/scanner/inclusive/naming-scanner.js'
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** A minimal inclusive term for "whitelist" at tier 1 (CRITICAL). */
+/** A minimal inclusive term for "whitelist" at tier 1 (WARNING — see #165). */
 const WHITELIST_TERM = {
   term: 'whitelist',
   tier: 1 as const,
@@ -193,7 +193,7 @@ describe('NamingScanner', () => {
 
       const finding = findings.find((f) => f.file === 'package.json');
       expect(finding).toBeDefined();
-      expect(finding!.severity).toBe(Severity.CRITICAL);
+      expect(finding!.severity).toBe(Severity.WARNING);
       expect(finding!.pillar).toBe(Pillar.INCLUSIVE);
       expect(finding!.category).toBe('inclusive-naming');
       expect(finding!.suggestion).toContain('allowlist');
@@ -245,7 +245,7 @@ describe('NamingScanner', () => {
       expect(pkgFindings).toHaveLength(0);
     });
 
-    it('maps tier 1 term to CRITICAL severity', async () => {
+    it('maps tier 1 term to WARNING severity', async () => {
       const scanner = setupScanner([WHITELIST_TERM]);
       (fs.existsSync as ReturnType<typeof vi.fn>).mockImplementation((p: unknown) =>
         (p as string).endsWith('package.json')
@@ -260,7 +260,7 @@ describe('NamingScanner', () => {
       const findings = await scanner.run(createContext());
 
       const finding = findings.find((f) => f.file === 'package.json');
-      expect(finding!.severity).toBe(Severity.CRITICAL);
+      expect(finding!.severity).toBe(Severity.WARNING);
     });
 
     it('maps tier 2 term to WARNING severity', async () => {
@@ -321,7 +321,7 @@ describe('NamingScanner', () => {
 
       const finding = findings.find((f) => f.file === 'README.md');
       expect(finding).toBeDefined();
-      expect(finding!.severity).toBe(Severity.CRITICAL);
+      expect(finding!.severity).toBe(Severity.WARNING);
       expect(finding!.category).toBe('inclusive-naming');
     });
 
@@ -390,7 +390,7 @@ describe('NamingScanner', () => {
 
       const finding = findings.find((f) => f.file === null);
       expect(finding).toBeDefined();
-      expect(finding!.severity).toBe(Severity.CRITICAL);
+      expect(finding!.severity).toBe(Severity.WARNING);
       expect(finding!.category).toBe('inclusive-naming');
       expect(finding!.suggestion).toContain('allowlist');
     });


### PR DESCRIPTION
## Summary
Closes #165.
- `Severity.CRITICAL` is now reserved for harm-class (security/legal/operational) findings across all pillars.
- Inclusive-language scanners cap at `WARNING`: `tierToSeverity` in `naming-scanner.ts` now maps Tier 1 and Tier 2 to WARNING; Tier 3 to INFO.
- The welcoming-score summary in `diminishing-scanner.ts` cannot emit CRITICAL — sub-60 scores produce WARNING.
- INI tier is surfaced as a first-class label in markdown reports: `[Tier N — Replace Immediately / Strongly Consider / Recommended]` prefix for any finding with `metadata.tier`.
- PRD-v2.md updated: Stories 6.1c/6.1d/6.1e/6.2 severity wording corrected, plus a Severity Model decision record under Epic 6's 4-category framework section.

## Test plan
- [x] Red tests confirm: Tier 1 → WARNING; welcoming-score < 60 → WARNING; markdown shows Tier label; no CRITICAL from naming-scanner on any source
- [x] Defensive test: no diminishing-scanner finding has severity CRITICAL
- [x] `npm run test:coverage` green, ≥80% (1541 pass; 12 pre-existing CLI subprocess failures unrelated to this change)
- [x] Existing tests updated: `maps tier 1 term to CRITICAL severity` → `maps tier 1 term to WARNING severity`; `returns CRITICAL finding when welcoming score < 60` → `returns WARNING finding when welcoming score < 60`
