### PR TITLE
fix: cap doc-scanner and code-scanner inclusive findings at WARNING (#165 follow-up)

### DIFF
--- a/src/scanner/inclusive/code-scanner.ts
+++ b/src/scanner/inclusive/code-scanner.ts
@@ -44,13 +44,10 @@ const HASH_COMMENT_EXTENSIONS = new Set(['.py', '.rb']);
 /** Per-line suppression marker. */
 const SUPPRESSION_MARKER = 'inclusive-naming-ignore';
 
-/**
- * Map term tiers to finding severities.
- */
 function tierToSeverity(tier: 1 | 2 | 3): Severity {
+  // Tier 1 caps at WARNING; CRITICAL is reserved for harm-class findings (#165).
   switch (tier) {
     case 1:
-      return Severity.CRITICAL;
     case 2:
       return Severity.WARNING;
     case 3:

--- a/src/scanner/inclusive/doc-scanner.ts
+++ b/src/scanner/inclusive/doc-scanner.ts
@@ -24,14 +24,10 @@ const EXCLUDED_DIRS = ['node_modules', 'vendor', '.git'];
 /** Inline suppression comment that disables scanning for a line. */
 const SUPPRESSION_MARKER = '<!-- inclusive-naming-ignore -->';
 
-/**
- * Map term tier to finding severity.
- * Tier 1 = CRITICAL, Tier 2 = WARNING, Tier 3 = INFO.
- */
 function tierToSeverity(tier: 1 | 2 | 3): Severity {
+  // Tier 1 caps at WARNING; CRITICAL is reserved for harm-class findings (#165).
   switch (tier) {
     case 1:
-      return Severity.CRITICAL;
     case 2:
       return Severity.WARNING;
     case 3:

--- a/tests/scanner/inclusive/code-scanner.test.ts
+++ b/tests/scanner/inclusive/code-scanner.test.ts
@@ -97,7 +97,7 @@ describe('InclusiveCodeScanner', () => {
       expect(findings.length).toBeGreaterThanOrEqual(1);
       const masterFinding = findings.find((f) => f.message.toLowerCase().includes('master'));
       expect(masterFinding).toBeDefined();
-      expect(masterFinding!.severity).toBe(Severity.CRITICAL);
+      expect(masterFinding!.severity).toBe(Severity.WARNING);
       expect(masterFinding!.file).toContain('app.ts');
       expect(masterFinding!.line).toBe(2);
     });
@@ -118,7 +118,7 @@ describe('InclusiveCodeScanner', () => {
       expect(findings.length).toBeGreaterThanOrEqual(1);
       const whitelistFinding = findings.find((f) => f.message.toLowerCase().includes('whitelist'));
       expect(whitelistFinding).toBeDefined();
-      expect(whitelistFinding!.severity).toBe(Severity.CRITICAL);
+      expect(whitelistFinding!.severity).toBe(Severity.WARNING);
       expect(whitelistFinding!.file).toContain('server.js');
     });
   });
@@ -137,7 +137,7 @@ describe('InclusiveCodeScanner', () => {
       expect(findings.length).toBeGreaterThanOrEqual(1);
       const blacklistFinding = findings.find((f) => f.message.toLowerCase().includes('blacklist'));
       expect(blacklistFinding).toBeDefined();
-      expect(blacklistFinding!.severity).toBe(Severity.CRITICAL);
+      expect(blacklistFinding!.severity).toBe(Severity.WARNING);
       expect(blacklistFinding!.file).toContain('script.py');
       expect(blacklistFinding!.line).toBe(2);
     });
@@ -319,7 +319,7 @@ describe('InclusiveCodeScanner', () => {
   });
 
   describe('severity mapping', () => {
-    it('maps tier 1 to CRITICAL, tier 2 to WARNING, tier 3 to INFO', async () => {
+    it('maps tier 1 to WARNING, tier 2 to WARNING, tier 3 to INFO (#165)', async () => {
       writeFixture(tmpDir, 'mixed.ts', [
         '// The whitelist config',
         '// Sanity check this logic',
@@ -331,7 +331,7 @@ describe('InclusiveCodeScanner', () => {
 
       const whitelistF = findings.find((f) => f.message.toLowerCase().includes('whitelist'));
       expect(whitelistF).toBeDefined();
-      expect(whitelistF!.severity).toBe(Severity.CRITICAL);
+      expect(whitelistF!.severity).toBe(Severity.WARNING);
 
       const sanityF = findings.find((f) => f.message.toLowerCase().includes('sanity'));
       expect(sanityF).toBeDefined();
@@ -340,6 +340,20 @@ describe('InclusiveCodeScanner', () => {
       const manHoursF = findings.find((f) => f.message.toLowerCase().includes('man-hour'));
       expect(manHoursF).toBeDefined();
       expect(manHoursF!.severity).toBe(Severity.INFO);
+    });
+
+    it('never emits CRITICAL severity for any tier (#165)', async () => {
+      writeFixture(tmpDir, 'sample.ts', [
+        '// whitelist blacklist master-slave',
+        '// sanity check',
+        '// man-hours',
+      ].join('\n'));
+
+      const ctx = createContext(tmpDir);
+      const findings = await scanner.run(ctx);
+
+      const criticals = findings.filter((f) => f.severity === Severity.CRITICAL);
+      expect(criticals).toHaveLength(0);
     });
   });
 

--- a/tests/scanner/inclusive/doc-scanner.test.ts
+++ b/tests/scanner/inclusive/doc-scanner.test.ts
@@ -107,8 +107,8 @@ describe('InclusiveDocScanner', () => {
     });
   });
 
-  describe('tier 1 terms produce CRITICAL findings', () => {
-    it('finds tier 1 terms in .md files and returns CRITICAL findings', async () => {
+  describe('tier 1 terms produce WARNING findings (#165)', () => {
+    it('finds tier 1 terms in .md files and returns WARNING findings (capped per #165)', async () => {
       writeFixture(tmpDir, 'README.md', 'This uses a master-slave architecture.\n');
       const context = createScanContext(tmpDir);
 
@@ -117,8 +117,18 @@ describe('InclusiveDocScanner', () => {
       expect(findings.length).toBeGreaterThan(0);
       const finding = findings.find((f) => f.message.includes('master-slave'));
       expect(finding).toBeDefined();
-      expect(finding!.severity).toBe(Severity.CRITICAL);
+      expect(finding!.severity).toBe(Severity.WARNING);
       expect(finding!.pillar).toBe(Pillar.INCLUSIVE);
+    });
+
+    it('never emits CRITICAL severity for any tier (#165)', async () => {
+      writeFixture(tmpDir, 'README.md', 'master-slave whitelist blacklist sanity check man-hours\n');
+      const context = createScanContext(tmpDir);
+
+      const findings = await scanner.run(context);
+
+      const criticals = findings.filter((f) => f.severity === Severity.CRITICAL);
+      expect(criticals).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION
## Summary

Completes the scope of #165 by extending the tier→severity decoupling to `doc-scanner.ts` and `code-scanner.ts`, which were scoped out of PR #167 and were still emitting `Severity.CRITICAL` for INI Tier 1 terms.

Self-scan before this PR (on main with #167 merged): 1 remaining CRITICAL from `doc-scanner.ts`. After this PR: 0 CRITICAL findings in the inclusive pillar.

## Changes

- `src/scanner/inclusive/doc-scanner.ts` — `tierToSeverity`: Tier 1 and Tier 2 → `WARNING`; Tier 3 → `INFO`
- `src/scanner/inclusive/code-scanner.ts` — same change
- `tests/scanner/inclusive/doc-scanner.test.ts` — updated stale `CRITICAL` assertion; added "never emits CRITICAL" defensive test
- `tests/scanner/inclusive/code-scanner.test.ts` — updated three stale `CRITICAL` assertions; updated severity mapping test name and expectations; added "never emits CRITICAL" defensive test

## Test plan

- [x] Red commit confirms 7 tests failing on the stale CRITICAL expectations
- [x] Green commit: 49/49 inclusive doc+code scanner tests pass
- [x] Full suite: 1559/1559 tests pass; coverage 97.61% statements / 92.45% branches
