### PR TITLE
fix: per-term INI deep links for inclusive scanner findings (#174)

### DIFF
--- a/src/scanner/inclusive/code-scanner.ts
+++ b/src/scanner/inclusive/code-scanner.ts
@@ -314,7 +314,7 @@ export class InclusiveCodeScanner implements Scanner {
                 column: region.startCol + 1,
                 context: line.trim(),
                 suggestion: `Consider using: ${term.replacements.join(', ')}`,
-                referenceUrl: 'https://inclusivenaming.org/',
+                referenceUrl: term.referenceUrl ?? 'https://inclusivenaming.org/',
                 dataSource: 'local',
                 metadata: {
                   term: term.term,

--- a/src/scanner/inclusive/doc-scanner.ts
+++ b/src/scanner/inclusive/doc-scanner.ts
@@ -204,7 +204,7 @@ export class InclusiveDocScanner implements Scanner {
             column,
             context: contextSnippet,
             suggestion: `Replace "${matchedText}" with one of: ${term.replacements.join(', ')}`,
-            referenceUrl: 'https://inclusivenaming.org/word-lists/',
+            referenceUrl: term.referenceUrl ?? 'https://inclusivenaming.org/word-lists/',
             dataSource: 'local',
             metadata: {
               matchedText,

--- a/src/scanner/inclusive/naming-scanner.ts
+++ b/src/scanner/inclusive/naming-scanner.ts
@@ -152,7 +152,7 @@ export class NamingScanner implements Scanner {
         line: null,
         column: null,
         suggestion: `Rename the project using an alternative term per the Inclusive Naming Initiative: ${term.replacements.join(', ')}`,
-        referenceUrl: 'https://inclusivenaming.org/word-lists/',
+        referenceUrl: term.referenceUrl ?? 'https://inclusivenaming.org/word-lists/',
         dataSource: 'local',
         metadata: {
           term: term.term,
@@ -208,7 +208,7 @@ export class NamingScanner implements Scanner {
         line: null,
         column: null,
         suggestion: `Rename the project using an alternative term per the Inclusive Naming Initiative: ${term.replacements.join(', ')}`,
-        referenceUrl: 'https://inclusivenaming.org/word-lists/',
+        referenceUrl: term.referenceUrl ?? 'https://inclusivenaming.org/word-lists/',
         dataSource: 'local',
         metadata: {
           term: term.term,
@@ -267,7 +267,7 @@ export class NamingScanner implements Scanner {
         line: null,
         column: null,
         suggestion: `Rename the project using an alternative term per the Inclusive Naming Initiative: ${term.replacements.join(', ')}`,
-        referenceUrl: 'https://inclusivenaming.org/word-lists/',
+        referenceUrl: term.referenceUrl ?? 'https://inclusivenaming.org/word-lists/',
         dataSource: 'local',
         metadata: {
           term: term.term,

--- a/src/scanner/inclusive/term-list.ts
+++ b/src/scanner/inclusive/term-list.ts
@@ -13,6 +13,7 @@ export interface LoadedTerm {
   pattern: RegExp;
   replacements: string[];
   reason?: string;
+  referenceUrl?: string;
 }
 
 export interface LoadedTermList {
@@ -29,30 +30,35 @@ const TIER_1_TERMS: LoadedTerm[] = [
     tier: 1,
     pattern: /\bmaster[/-]slave\b/i,
     replacements: ['primary-secondary', 'leader-follower', 'controller-worker'],
+    referenceUrl: 'https://inclusivenaming.org/word-lists/tier-1/master-slave/',
   },
   {
     term: 'master',
     tier: 1,
     pattern: /\bmaster\b(?!mind|y|piece|ful)/i,
     replacements: ['main', 'primary', 'source', 'original'],
+    referenceUrl: 'https://inclusivenaming.org/word-lists/tier-1/master-slave/',
   },
   {
     term: 'slave',
     tier: 1,
     pattern: /\bslave\b/i,
     replacements: ['secondary', 'replica', 'follower', 'worker'],
+    referenceUrl: 'https://inclusivenaming.org/word-lists/tier-1/master-slave/',
   },
   {
     term: 'whitelist',
     tier: 1,
     pattern: /\bwhite[-]?list\b/i,
     replacements: ['allowlist', 'approved list', 'safe list'],
+    referenceUrl: 'https://inclusivenaming.org/word-lists/tier-1/whitelist/',
   },
   {
     term: 'blacklist',
     tier: 1,
     pattern: /\bblack[-]?list\b/i,
     replacements: ['blocklist', 'denylist', 'banned list'],
+    referenceUrl: 'https://inclusivenaming.org/word-lists/tier-1/blacklist/',
   },
   {
     term: 'blackhat',
@@ -71,6 +77,7 @@ const TIER_1_TERMS: LoadedTerm[] = [
     tier: 1,
     pattern: /\bgrandfather(?:ed|ing)?\b/i,
     replacements: ['legacy', 'exempted', 'preapproved'],
+    referenceUrl: 'https://inclusivenaming.org/word-lists/tier-2/grandfathered/',
   },
   {
     term: 'cripple',
@@ -89,6 +96,7 @@ const TIER_1_TERMS: LoadedTerm[] = [
     tier: 1,
     pattern: /\babort(?:ed|ing|s)?\b/i,
     replacements: ['cancel', 'terminate', 'stop', 'halt'],
+    referenceUrl: 'https://inclusivenaming.org/word-lists/tier-1/abort/',
   },
 ];
 
@@ -101,6 +109,7 @@ const TIER_2_TERMS: LoadedTerm[] = [
     tier: 2,
     pattern: /\bsanity[- ]?check\b/i,
     replacements: ['confidence check', 'validity check', 'coherence check'],
+    referenceUrl: 'https://inclusivenaming.org/word-lists/tier-2/sanity-check/',
   },
 ];
 

--- a/tests/scanner/reference-url.test.ts
+++ b/tests/scanner/reference-url.test.ts
@@ -597,6 +597,60 @@ describe('Tier B: Inclusive scanners — static referenceUrl', () => {
 });
 
 // ---------------------------------------------------------------------------
+// per-term INI deep-link referenceUrl (#174)
+// ---------------------------------------------------------------------------
+
+describe('per-term INI deep-link referenceUrl (#174)', () => {
+  let tmpDir: string;
+  beforeEach(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ini-deeplink-')); });
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('InclusiveCodeScanner: "abort" finding has per-term INI URL /tier-1/abort/', async () => {
+    const { InclusiveCodeScanner } = await import('../../src/scanner/inclusive/code-scanner.js');
+    const scanner = new InclusiveCodeScanner();
+    fs.writeFileSync(path.join(tmpDir, 'test.js'), '// abort the operation\n');
+    const ctx = makeContext(tmpDir);
+    const findings = await scanner.run(ctx);
+    const f = findings.find((x) => x.metadata?.term === 'abort');
+    expect(f).toBeDefined();
+    expect(f!.referenceUrl).toContain('/word-lists/tier-1/abort');
+  });
+
+  it('InclusiveCodeScanner: "whitelist" finding has per-term INI URL /tier-1/whitelist/', async () => {
+    const { InclusiveCodeScanner } = await import('../../src/scanner/inclusive/code-scanner.js');
+    const scanner = new InclusiveCodeScanner();
+    fs.writeFileSync(path.join(tmpDir, 'test.js'), '// use the whitelist\n');
+    const ctx = makeContext(tmpDir);
+    const findings = await scanner.run(ctx);
+    const f = findings.find((x) => x.metadata?.term === 'whitelist');
+    expect(f).toBeDefined();
+    expect(f!.referenceUrl).toContain('/word-lists/tier-1/whitelist');
+  });
+
+  it('InclusiveCodeScanner: "master" finding has per-term INI URL /tier-1/master-slave/', async () => {
+    const { InclusiveCodeScanner } = await import('../../src/scanner/inclusive/code-scanner.js');
+    const scanner = new InclusiveCodeScanner();
+    fs.writeFileSync(path.join(tmpDir, 'test.js'), '// master branch config\n');
+    const ctx = makeContext(tmpDir);
+    const findings = await scanner.run(ctx);
+    const f = findings.find((x) => x.metadata?.term === 'master');
+    expect(f).toBeDefined();
+    expect(f!.referenceUrl).toContain('/word-lists/tier-1/master-slave');
+  });
+
+  it('InclusiveDocScanner: "sanity check" finding has per-term INI URL /tier-2/sanity-check/', async () => {
+    const { InclusiveDocScanner } = await import('../../src/scanner/inclusive/doc-scanner.js');
+    const scanner = new InclusiveDocScanner();
+    fs.writeFileSync(path.join(tmpDir, 'README.md'), 'Do a sanity check before deploying.\n');
+    const ctx = makeContext(tmpDir);
+    const findings = await scanner.run(ctx);
+    const f = findings.find((x) => String(x.metadata?.matchedText ?? '').toLowerCase().includes('sanity'));
+    expect(f).toBeDefined();
+    expect(f!.referenceUrl).toContain('/word-lists/tier-2/sanity-check');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tier B — Technical scanners
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Closes #174.
- Added `referenceUrl?: string` to `LoadedTerm` interface so each bundled term can carry a per-term INI deep link.
- Set per-term INI URLs on 8 bundled terms with confirmed deep-link pages: `abort`, `whitelist`, `blacklist`, `master`, `slave`, `master-slave`, `grandfathered`, `sanity check`.
- Updated naming-scanner, code-scanner, and doc-scanner to use `term.referenceUrl ?? fallback` instead of a hardcoded base URL.

## Test plan
- [x] Red tests confirm base-URL-only behavior before fix (tests/scanner/reference-url.test.ts, new describe block)
- [x] `npm run test:coverage` green, 97.62% coverage (≥80%)
- [x] PRD update: n/a (bug fix, no documented behavior change)
- [x] README update: no