### PR TITLE
fix: reduce INFO pillar score deduction to prevent inclusive score 0.0 (#175)

### DIFF
--- a/src/scanner/orchestrator.ts
+++ b/src/scanner/orchestrator.ts
@@ -270,8 +270,11 @@ export class Orchestrator {
     const total = criticalCount + warningCount + infoCount + passCount;
     if (total === 0) return 10.0;
 
-    // Deductions: critical = 3 points, warning = 1.5 points, info = 0.5 points
-    const deductions = criticalCount * 3 + warningCount * 1.5 + infoCount * 0.5;
+    // Deductions: critical = 3 points, warning = 1.5 points, info = 0.1 points
+    // INFO findings are informational suggestions, not defects — a low weight
+    // prevents scanners that emit many INFO items (e.g. acronym/assumed-knowledge)
+    // from collapsing the pillar score to zero. See #175.
+    const deductions = criticalCount * 3 + warningCount * 1.5 + infoCount * 0.1;
     const score = Math.max(0, 10.0 - deductions);
 
     return Math.round(score * 10) / 10;

--- a/tests/scanner/orchestrator.test.ts
+++ b/tests/scanner/orchestrator.test.ts
@@ -529,6 +529,63 @@ describe('Orchestrator', () => {
     });
   });
 
+  describe('inclusive pillar score with INFO-heavy findings (#175)', () => {
+    it('scores inclusive pillar > 0 when scanner returns 20 INFO findings and 2 WARNING findings', async () => {
+      // Arrange: 20 INFO acronym findings + 2 WARNING naming findings — typical real-repo output
+      const infoFindings = Array.from({ length: 20 }, (_, i) =>
+        createFinding({
+          id: `INC-INFO-${String(i + 1).padStart(2, '0')}`,
+          severity: Severity.INFO,
+          pillar: Pillar.INCLUSIVE,
+        }),
+      );
+      const warningFindings = [
+        createFinding({ id: 'INC-WARN-01', severity: Severity.WARNING, pillar: Pillar.INCLUSIVE }),
+        createFinding({ id: 'INC-WARN-02', severity: Severity.WARNING, pillar: Pillar.INCLUSIVE }),
+      ];
+
+      registry.register(createMockScanner({
+        name: 'inclusive-scanner',
+        pillar: Pillar.INCLUSIVE,
+        findings: [...infoFindings, ...warningFindings],
+      }));
+
+      // Act
+      const result = await orchestrator.run(createMinimalContext());
+
+      // Assert: with old formula (infoCount * 0.5) → 20*0.5 + 2*1.5 = 13 deductions → score = 0
+      //         with new formula (infoCount * 0.1) → 20*0.1 + 2*1.5 = 5 deductions → score = 5
+      expect(result.pillars[Pillar.INCLUSIVE].score).toBeGreaterThan(0);
+    });
+
+    it('scores inclusive pillar approximately 5.0 with 20 INFO + 2 WARNING findings after fix', async () => {
+      // Arrange
+      const infoFindings = Array.from({ length: 20 }, (_, i) =>
+        createFinding({
+          id: `INC-INFO-${String(i + 1).padStart(2, '0')}`,
+          severity: Severity.INFO,
+          pillar: Pillar.INCLUSIVE,
+        }),
+      );
+      const warningFindings = [
+        createFinding({ id: 'INC-WARN-01', severity: Severity.WARNING, pillar: Pillar.INCLUSIVE }),
+        createFinding({ id: 'INC-WARN-02', severity: Severity.WARNING, pillar: Pillar.INCLUSIVE }),
+      ];
+
+      registry.register(createMockScanner({
+        name: 'inclusive-scanner-calibration',
+        pillar: Pillar.INCLUSIVE,
+        findings: [...infoFindings, ...warningFindings],
+      }));
+
+      // Act
+      const result = await orchestrator.run(createMinimalContext());
+
+      // Assert: 20*0.1 + 2*1.5 = 5.0 deductions → score = max(0, 10 - 5) = 5.0
+      expect(result.pillars[Pillar.INCLUSIVE].score).toBeCloseTo(5.0, 1);
+    });
+  });
+
   describe('scannerTimeout fallback (#135)', () => {
     it('uses DEFAULT_CONFIG.scannerTimeout when config.scannerTimeout is undefined', async () => {
       let timeoutUsed = 0;


### PR DESCRIPTION
## Summary
Closes #175.
- Reduces INFO finding deduction in `calculatePillarScore` from 0.5 to 0.1.
- The inclusive pillar was always scoring 0.0 because acronym/assumed-knowledge scanners generate 20+ INFO findings per typical repo, each deducting 0.5 points (total ≥ 10 → score clamped to 0).
- INFO findings are informational suggestions, not defects — they should only lightly affect the pillar score.

## Test plan
- [x] Red test: pillar with 20 INFO + 2 WARNING findings scores 0 before fix, >0 after fix (tests/scanner/orchestrator.test.ts)
- [x] `npm run test:coverage` green, ≥80% (98.95% statements, 86.12% branches, 100% functions)
- [x] PRD update: n/a (scoring calibration, not a documented behavior change)
- [x] README update: no
