### PR TITLE
fix: renderIssueBody — verify selector, report URL, per-pillar rationale (#182 #183 #184)

### DIFF
--- a/src/issues.ts
+++ b/src/issues.ts
@@ -10,16 +10,58 @@ export function isErrorFinding(f: Finding): boolean {
 }
 
 /**
+ * Builds a jq filter expression that selects findings matching this finding.
+ *
+ * When `category` is a non-empty, non-"unknown" string, uses an exact category
+ * match.  Falls back to an ID-prefix `startswith` match so the before/after
+ * verify command is always functional even when category is absent.
+ */
+function buildVerifySelector(finding: Finding): string {
+  const cat = finding.category;
+  if (cat && cat !== 'unknown') {
+    return `select(.category == "${cat}")`;
+  }
+  // Strip trailing counter (e.g. "inclusive-code-scanner-3" → "inclusive-code-scanner")
+  const idPrefix = finding.id.replace(/-\d+$/, '');
+  return `select(.id | startswith("${idPrefix}"))`;
+}
+
+/** Per-pillar rationale sentences explaining the real-world impact. */
+const PILLAR_RATIONALE: Record<string, string> = {
+  security: 'Security gaps create exploitable attack surfaces that can compromise the project, its users, and downstream dependents.',
+  governance: 'Without clear governance signals (license, code of conduct, security policy), contributors and adopters cannot assess whether the project is safe to use or contribute to.',
+  community: 'Community health signals directly affect whether new contributors discover, join, and stay in the project.',
+  inclusive: 'Inclusive language and clear terminology lower the barrier for contributors from diverse backgrounds and reduce friction for newcomers.',
+  technical: 'Technical hygiene issues (missing tests, linting, CI) compound over time — each unaddressed gap makes the next change riskier.',
+  ai_readiness: 'AI-native tooling relies on structured, machine-readable project context; gaps here reduce the quality of AI-assisted development workflows for this project.',
+};
+
+/**
+ * Returns a one-sentence rationale explaining why a finding in the given pillar
+ * matters.  Falls back to a generic message when the pillar is unrecognised.
+ */
+function pillarRationale(pillar: string): string {
+  return PILLAR_RATIONALE[pillar] ?? `This finding affects the **${pillar}** pillar and will continue to appear in every future scan until resolved.`;
+}
+
+/**
  * Renders a structured, agent-executable GitHub issue body from a single finding.
  * Produces five sections (What / Why / How to fix / How to verify / Context)
  * with enough specificity that a coding agent can act on the issue alone.
+ *
+ * @param finding   The scanner finding to render.
+ * @param report    The scan report that produced the finding (used for score and date).
+ * @param reportUrl Optional URL to the full scan report (e.g. a GitHub Actions summary
+ *                  or a hosted HTML report).  When supplied, a **Full report:** link is
+ *                  added to the Context section.
  */
-export function renderIssueBody(finding: Finding, report: ScanReport): string {
+export function renderIssueBody(finding: Finding, report: ScanReport, reportUrl?: string): string {
   const severity = typeof finding.severity === 'number'
     ? ['PASS', 'INFO', 'WARNING', 'CRITICAL'][finding.severity] ?? String(finding.severity)
     : String(finding.severity);
 
-  const verifyCmd = `quaid-scanner . --format json | jq '[.findings[] | select(.category == "${finding.category ?? 'unknown'}")] | length'`;
+  const verifySelector = buildVerifySelector(finding);
+  const verifyCmd = `quaid-scanner . --format json | jq '[.findings[] | ${verifySelector}] | length'`;
 
   const lines: string[] = [
     `<!-- quaid-scanner finding — pillar: ${finding.pillar}, severity: ${severity} -->`,
@@ -31,7 +73,7 @@ export function renderIssueBody(finding: Finding, report: ScanReport): string {
     ``,
     `## Why it matters`,
     ``,
-    `This finding is dragging down the **${finding.pillar}** pillar score (current report: ${report.overallScore.toFixed(1)}/10 overall). Leaving it unaddressed means this signal will continue to appear in every future scan.`,
+    pillarRationale(finding.pillar),
     ``,
     `## How to fix it`,
     ``,
@@ -54,6 +96,7 @@ export function renderIssueBody(finding: Finding, report: ScanReport): string {
     `- **Data source:** ${finding.dataSource ?? 'local'}`,
     finding.referenceUrl ? `- **Reference:** ${finding.referenceUrl}` : '',
     `- **Scan report:** scored ${report.overallScore.toFixed(1)}/10 on ${report.scannedAt.slice(0, 10)}`,
+    reportUrl ? `- **Full report:** ${reportUrl}` : '',
     ``,
     `---`,
     `*Identified by [quaid-scanner](https://github.com/quaid/quaid-scanner) v${report.version} on ${report.scannedAt.slice(0, 10)}.*`,

--- a/tests/issues.test.ts
+++ b/tests/issues.test.ts
@@ -123,3 +123,88 @@ describe('renderIssueBody (#143)', () => {
     expect(body).toContain('quaid-scanner');
   });
 });
+
+// ── Bug #183 — verify selector falls back when category is null ────────────────
+
+describe('renderIssueBody — verify selector (#183)', () => {
+  it('uses category-based selector when category is a real string', () => {
+    const body = renderIssueBody(makeFinding({ category: 'code-of-conduct' }), makeReport());
+    expect(body).toContain('select(.category == "code-of-conduct")');
+  });
+
+  it('does NOT emit "unknown" in the verify command when category is null', () => {
+    const finding = makeFinding({ id: 'inclusive-code-scanner-3', category: undefined });
+    // Force category to null at runtime (the type says string but runtime may produce null/undefined)
+    (finding as unknown as Record<string, unknown>)['category'] = null;
+    const body = renderIssueBody(finding, makeReport());
+    // The verify command line must not contain the literal word "unknown"
+    const verifyLine = body.split('\n').find((l) => l.includes('quaid-scanner') && l.includes('jq'));
+    expect(verifyLine).toBeDefined();
+    expect(verifyLine).not.toContain('"unknown"');
+  });
+
+  it('falls back to ID-prefix startswith selector when category is null', () => {
+    const finding = makeFinding({ id: 'inclusive-code-scanner-3', category: undefined });
+    (finding as unknown as Record<string, unknown>)['category'] = null;
+    const body = renderIssueBody(finding, makeReport());
+    expect(body).toContain('startswith("inclusive-code-scanner")');
+  });
+});
+
+// ── Bug #184 — optional reportUrl in Context section ──────────────────────────
+
+describe('renderIssueBody — report URL (#184)', () => {
+  it('includes the report URL in Context when reportUrl is supplied', () => {
+    const body = renderIssueBody(
+      makeFinding(),
+      makeReport(),
+      'https://github.com/org/repo/pull/42',
+    );
+    expect(body).toContain('https://github.com/org/repo/pull/42');
+    expect(body).toContain('**Full report:**');
+  });
+
+  it('does NOT include a Full report line when reportUrl is omitted', () => {
+    const body = renderIssueBody(makeFinding(), makeReport());
+    expect(body).not.toContain('**Full report:**');
+  });
+});
+
+// ── Bug #182 — per-pillar rationale in "Why it matters" ───────────────────────
+
+describe('renderIssueBody — per-pillar rationale (#182)', () => {
+  it('uses security-specific rationale for security pillar findings', () => {
+    const body = renderIssueBody(makeFinding({ pillar: Pillar.SECURITY }), makeReport());
+    expect(body).toMatch(/[Ss]ecurity gaps|attack surface/);
+  });
+
+  it('uses governance-specific rationale for governance pillar findings', () => {
+    const body = renderIssueBody(makeFinding({ pillar: Pillar.GOVERNANCE }), makeReport());
+    expect(body).toMatch(/governance|license|[Cc]ode of [Cc]onduct/);
+  });
+
+  it('uses community-specific rationale for community pillar findings', () => {
+    const body = renderIssueBody(makeFinding({ pillar: Pillar.COMMUNITY }), makeReport());
+    expect(body).toMatch(/[Cc]ommunity health|contributor/i);
+  });
+
+  it('uses inclusive-specific rationale for inclusive pillar findings', () => {
+    const body = renderIssueBody(makeFinding({ pillar: Pillar.INCLUSIVE }), makeReport());
+    expect(body).toMatch(/[Ii]nclusive|barrier|newcomer/i);
+  });
+
+  it('uses technical-specific rationale for technical pillar findings', () => {
+    const body = renderIssueBody(makeFinding({ pillar: Pillar.TECHNICAL }), makeReport());
+    expect(body).toMatch(/[Tt]echnical|hygiene|tests|CI/i);
+  });
+
+  it('uses ai_readiness-specific rationale for ai_readiness pillar findings', () => {
+    const body = renderIssueBody(makeFinding({ pillar: Pillar.AI_READINESS }), makeReport());
+    expect(body).toMatch(/AI|machine-readable|agent/i);
+  });
+
+  it('does NOT contain the old generic boilerplate phrase', () => {
+    const body = renderIssueBody(makeFinding({ pillar: Pillar.SECURITY }), makeReport());
+    expect(body).not.toContain('dragging down the');
+  });
+});

--- a/tests/issues.test.ts
+++ b/tests/issues.test.ts
@@ -207,4 +207,17 @@ describe('renderIssueBody — per-pillar rationale (#182)', () => {
     const body = renderIssueBody(makeFinding({ pillar: Pillar.SECURITY }), makeReport());
     expect(body).not.toContain('dragging down the');
   });
+
+  it('falls back gracefully for an unrecognised pillar string', () => {
+    const finding = makeFinding({ pillar: 'experimental' as Pillar });
+    const body = renderIssueBody(finding, makeReport());
+    expect(body).toContain('experimental');
+    expect(body).not.toContain('dragging down the');
+  });
+
+  it('handles a non-numeric severity value without throwing', () => {
+    const finding = makeFinding({ severity: 'CRITICAL' as unknown as typeof Severity.CRITICAL });
+    const body = renderIssueBody(finding, makeReport());
+    expect(body).toContain('CRITICAL');
+  });
 });

--- a/tests/reporters/json.test.ts
+++ b/tests/reporters/json.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { buildScanReport, serializeJson } from '../../src/reporters/json.js';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { buildScanReport, serializeJson, localISOString } from '../../src/reporters/json.js';
 import { DEFAULT_CONFIG } from '../../src/config.js';
 import {
   Pillar,
@@ -213,5 +213,100 @@ describe('serializeJson', () => {
     const report = buildScanReport(target, makeResult(), DEFAULT_CONFIG, MaturityLevel.SANDBOX, '1.0.0');
     expect(report.partial).toBe(false);
     expect(report.failedScanners).toHaveLength(0);
+  });
+});
+
+describe('localISOString (#188)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not end in Z (UTC marker) for a fixed UTC instant', () => {
+    // 2026-06-05T23:30:00Z is a known UTC instant
+    const d = new Date('2026-06-05T23:30:00Z');
+    const result = localISOString(d);
+    expect(result.endsWith('Z')).toBe(false);
+  });
+
+  it('contains a timezone offset sign (+ or -)', () => {
+    const d = new Date('2026-06-05T23:30:00Z');
+    const result = localISOString(d);
+    // Must contain an offset like +00:00, -07:00, +05:30, etc.
+    expect(result).toMatch(/[+-]\d{2}:\d{2}$/);
+  });
+
+  it('produces a string matching ISO 8601 with offset format', () => {
+    const d = new Date('2026-06-05T12:00:00Z');
+    const result = localISOString(d);
+    // e.g. 2026-06-05T05:00:00-07:00  or  2026-06-05T12:00:00+00:00
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/);
+  });
+
+  it('uses the local date portion relative to the Date object, not UTC', () => {
+    // Construct a Date at exactly midnight UTC, which is the previous local day
+    // for any timezone behind UTC (e.g. Americas).
+    // We verify the format is correct regardless of host TZ, by computing
+    // expected values from the Date object itself.
+    const d = new Date('2026-06-06T00:00:00Z');
+    const result = localISOString(d);
+    const expectedYear = String(d.getFullYear());
+    const expectedMonth = String(d.getMonth() + 1).padStart(2, '0');
+    const expectedDay = String(d.getDate()).padStart(2, '0');
+    expect(result.startsWith(`${expectedYear}-${expectedMonth}-${expectedDay}T`)).toBe(true);
+  });
+
+  it('produces correct offset string for a positive UTC offset', () => {
+    // Simulate +05:30 (India) by overriding getTimezoneOffset
+    const d = new Date('2026-06-05T12:00:00Z');
+    const originalGetTimezoneOffset = d.getTimezoneOffset.bind(d);
+    d.getTimezoneOffset = () => -330; // -330 minutes = +05:30
+    const result = localISOString(d);
+    expect(result.endsWith('+05:30')).toBe(true);
+    d.getTimezoneOffset = originalGetTimezoneOffset;
+  });
+
+  it('produces correct offset string for a negative UTC offset', () => {
+    // Simulate -07:00 (Pacific) by overriding getTimezoneOffset
+    const d = new Date('2026-06-05T23:30:00Z');
+    d.getTimezoneOffset = () => 420; // 420 minutes = -07:00
+    const result = localISOString(d);
+    expect(result.endsWith('-07:00')).toBe(true);
+  });
+
+  it('produces UTC+00:00 offset for a zero-offset date', () => {
+    const d = new Date('2026-06-05T10:00:00Z');
+    d.getTimezoneOffset = () => 0;
+    const result = localISOString(d);
+    expect(result.endsWith('+00:00')).toBe(true);
+  });
+});
+
+describe('buildScanReport scannedAt timezone (#188)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('scannedAt does not end with Z', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-05T23:30:00Z'));
+    const target = { type: 'local' as const, value: '/tmp/test-repo' };
+    const report = buildScanReport(target, makeResult(), DEFAULT_CONFIG, MaturityLevel.SANDBOX, '1.0.0');
+    expect(report.scannedAt.endsWith('Z')).toBe(false);
+  });
+
+  it('scannedAt contains a timezone offset', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-05T23:30:00Z'));
+    const target = { type: 'local' as const, value: '/tmp/test-repo' };
+    const report = buildScanReport(target, makeResult(), DEFAULT_CONFIG, MaturityLevel.SANDBOX, '1.0.0');
+    expect(report.scannedAt).toMatch(/[+-]\d{2}:\d{2}$/);
+  });
+
+  it('scannedAt matches ISO 8601 with offset format', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-05T12:00:00Z'));
+    const target = { type: 'local' as const, value: '/tmp/test-repo' };
+    const report = buildScanReport(target, makeResult(), DEFAULT_CONFIG, MaturityLevel.SANDBOX, '1.0.0');
+    expect(report.scannedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/);
   });
 });


### PR DESCRIPTION
## Summary

Closes #182. Closes #183. Closes #184.

Three fixes to `renderIssueBody` in `src/issues.ts`:

- **#183** — Verify commands no longer emit `"unknown"` for null-category findings. Falls back to an ID-prefix `startswith` selector so the before/after check is always functional.
- **#184** — Added optional `reportUrl?: string` third argument; when supplied, the Context section includes a `**Full report:**` link so maintainers can navigate to the full scan.
- **#182** — "Why it matters" replaced generic score-boilerplate with a per-pillar rationale sentence that explains the real-world impact of the finding type.

## Test plan
- [x] Red tests for all three behaviours (tests/issues.test.ts)
- [x] `npm run test:coverage` green, ≥80%
- [x] PRD update: n/a (output quality improvement)
- [x] README update: no