### PR TITLE
fix: expand common-words dictionary and emphasis denylist (#151)

### DIFF
--- a/src/scanner/inclusive/assumed-knowledge-scanner.ts
+++ b/src/scanner/inclusive/assumed-knowledge-scanner.ts
@@ -59,7 +59,9 @@ const EMPHASIS_WORD_DENYLIST = new Set<string>([
   // Code comment markers
   'TODO', 'FIXME', 'XXX', 'HACK',
   // Common documentation file names used inline
-  'README', 'CHANGELOG', 'LICENSE', 'AUTHORS', 'COPYING',
+  'README', 'CHANGELOG', 'LICENSE', 'AUTHORS', 'COPYING', 'CONTRIBUTING',
+  // Well-known product / tool proper names — not acronyms, not undefined
+  'CLAUDE', 'GITHUB', 'GITLAB', 'DOCKER', 'LINUX', 'WINDOWS', 'MACOS',
   // Status / requirement adjectives
   'ESTABLISHED', 'REQUIRED', 'OPTIONAL', 'DEPRECATED', 'OBSOLETE',
   // Boolean / null literals

--- a/src/scanner/inclusive/data/common-english-words.ts
+++ b/src/scanner/inclusive/data/common-english-words.ts
@@ -289,4 +289,37 @@ export const COMMON_ENGLISH_WORDS: ReadonlySet<string> = new Set([
   // Words from reopener that MUST be present
   'new', 'security', 'active', 'never', 'always', 'required',
   'start', 'stop', 'open', 'ready',
+
+  // Size / degree adjectives — commonly appear ALL-CAPS in docs (#151 regression)
+  'major', 'minor', 'significant', 'substantial', 'considerable',
+  'moderate', 'extensive', 'partial', 'complete', 'full',
+  'high', 'medium', 'low', 'severe', 'trivial',
+
+  // Intellectual / conceptual nouns (#151 regression: IDEA)
+  'idea', 'concept', 'notion', 'thought', 'theory', 'principle',
+  'overview', 'summary', 'description', 'definition', 'specification',
+  'explanation', 'example', 'sample', 'draft', 'outline', 'proposal',
+
+  // Process / contribution words (#151 regression: CONTRIBUTING)
+  'contributing', 'contribution', 'contributions', 'contributor',
+  'implementation', 'setup', 'teardown', 'migration', 'upgrade',
+  'installation', 'configuration', 'deployment', 'release',
+
+  // Placeholder / template words (#151 regression: PLACEHOLDER)
+  'placeholder', 'template', 'scaffold', 'boilerplate', 'skeleton',
+  'section', 'portion', 'segment', 'item', 'entry', 'slot', 'blank',
+
+  // Common nouns missing from earlier sweep
+  'caution', 'notice', 'reminder',
+  'stage', 'phase', 'iteration', 'cycle', 'round',
+  'goal', 'objective', 'purpose', 'intent', 'aim',
+  'reason', 'cause', 'effect', 'outcome', 'impact',
+  'change', 'difference', 'improvement', 'enhancement', 'addition', 'removal',
+
+  // Common verbs missing from earlier sweep
+  'contribute', 'review', 'approve', 'reject', 'accept', 'decline',
+  'exclude', 'include', 'append', 'prepend',
+  'expand', 'collapse', 'wrap', 'unwrap',
+  'increase', 'decrease', 'increment', 'decrement',
+  'activate', 'deactivate', 'toggle',
 ]);


### PR DESCRIPTION
## Summary

- Expands `COMMON_ENGLISH_WORDS` with missing everyday English words (`idea`, `major`, `minor`, `placeholder`, `contributing`, and semantic neighbours) that were incorrectly flagged as undefined acronyms
- Adds `CONTRIBUTING`, well-known product names, and doc file names to `EMPHASIS_WORD_DENYLIST` — these are not acronyms

## Test plan

- [ ] Rescan agentic-rules: `IDEA`, `PLACEHOLDER`, `CONTRIBUTING`, `MAJOR`, `MINOR` no longer appear as acronym findings
- [ ] Genuine technical acronyms (`MCP`, `MVP`, `TDD`, `BDD`, `LLM`) still flagged
- [ ] `npm run build` passes with no type errors

Closes #151