### PR TITLE
fix: principled acronym heuristic — suffix/length/vowel layers (#192)

### DIFF
--- a/src/scanner/inclusive/assumed-knowledge-scanner.ts
+++ b/src/scanner/inclusive/assumed-knowledge-scanner.ts
@@ -77,6 +77,62 @@ const PREREQUISITES_HEADING = /^#{1,3}\s+(prerequisites|requirements)\s*$/im;
 const ACRONYM_PATTERN = /\b[A-Z]{3,}\b/g;
 
 /**
+ * Common English word suffixes. A token that ends with one of these is almost
+ * certainly a real English word used for emphasis, not a technical initialism.
+ *
+ * Layer 1 of the layered false-positive suppression heuristic (#192).
+ */
+const WORD_SUFFIXES = [
+  'ED', 'ING', 'ION', 'TION', 'SION', 'ITY', 'NESS',
+  'MENT', 'FUL', 'LESS', 'ABLE', 'IBLE', 'LY', 'ER', 'EST',
+  'NCE', 'ANCE', 'ENCE', 'ISM', 'IST', 'IVE', 'OUS',
+] as const;
+
+/**
+ * Tokens longer than this are almost certainly English words used for
+ * emphasis, not technical initialisms.
+ *
+ * Layer 2 of the layered false-positive suppression heuristic (#192).
+ */
+const MAX_ACRONYM_LENGTH = 5;
+
+/**
+ * Returns true when `token` ends with a recognisable English word suffix.
+ * Used as layer 1 of the false-positive heuristic.
+ */
+function hasWordSuffix(token: string): boolean {
+  return WORD_SUFFIXES.some((s) => token.endsWith(s));
+}
+
+/**
+ * Returns the ratio of vowels to total characters in `token`.
+ * Real English words tend to have a ratio above ~35%.
+ * Used as layer 3 of the false-positive heuristic.
+ */
+function vowelRatio(token: string): number {
+  const vowels = (token.match(/[AEIOU]/g) ?? []).length;
+  return vowels / token.length;
+}
+
+/**
+ * Returns true when `token` is likely a real English word used for emphasis
+ * rather than a genuine undefined acronym. Applies three layers:
+ *   1. Morphological suffix check (fastest — catches most English words)
+ *   2. Length threshold (>5 chars are almost never initialisms)
+ *   3. Vowel-ratio check (≥4 chars with >35% vowels read as pronounceable words)
+ *
+ * The existing `COMMON_ENGLISH_WORDS` dictionary is retained as a fast path
+ * that is checked before calling this function.
+ */
+function isLikelyWord(token: string): boolean {
+  return (
+    hasWordSuffix(token) ||                              // layer 1
+    token.length > MAX_ACRONYM_LENGTH ||                 // layer 2
+    (token.length >= 4 && vowelRatio(token) > 0.35)     // layer 3
+  );
+}
+
+/**
  * Scanner that detects assumed prerequisite knowledge in documentation.
  *
  * Checks for:
@@ -222,10 +278,10 @@ export class AssumedKnowledgeScanner implements Scanner {
           continue;
         }
 
-        // Skip real English words used as ALL-CAPS emphasis (e.g. NEW, NEVER, SECURITY)
-        // A curated denylist can never keep up with arbitrary English vocabulary, so
-        // we check against a vendored common-words set instead (#151 reopen).
-        if (COMMON_ENGLISH_WORDS.has(acronym.toLowerCase())) {
+        // Skip real English words used as ALL-CAPS emphasis (e.g. NEW, NEVER, SECURITY).
+        // The dictionary is the fast path; the layered heuristic (#192) catches the long
+        // tail without requiring ongoing dictionary maintenance.
+        if (COMMON_ENGLISH_WORDS.has(acronym.toLowerCase()) || isLikelyWord(acronym)) {
           continue;
         }
 

--- a/src/scanner/inclusive/term-list.ts
+++ b/src/scanner/inclusive/term-list.ts
@@ -134,6 +134,7 @@ const TIER_3_TERMS: LoadedTerm[] = [
     tier: 3,
     pattern: /\bend[- ]?of[- ]?life\b/i,
     replacements: ['deprecated', 'sunset', 'end of support'],
+    referenceUrl: 'https://inclusivenaming.org/word-lists/tier-3/end-of-life/',
   },
   {
     term: 'evangelist',

--- a/tests/scanner/inclusive/assumed-knowledge-scanner.test.ts
+++ b/tests/scanner/inclusive/assumed-knowledge-scanner.test.ts
@@ -628,4 +628,147 @@ describe('AssumedKnowledgeScanner', () => {
       expect(hcsFinding!.severity).toBe(Severity.INFO);
     });
   });
+
+  describe('layered acronym heuristics (#192)', () => {
+    // Layer 1 — morphological suffix suppression
+    it('does not flag REDACTED as undefined acronym (suffix -ED)', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'README.md'),
+        '# Project\n\nThe token value is REDACTED for security reasons.\n',
+      );
+
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const finding = findings.find(
+        (f) => f.category === 'undefined-acronym' && f.message.includes('"REDACTED"'),
+      );
+      expect(finding).toBeUndefined();
+    });
+
+    it('does not flag PROFANITY as undefined acronym (suffix -ITY)', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'README.md'),
+        '# Project\n\nContent containing PROFANITY is not allowed.\n',
+      );
+
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const finding = findings.find(
+        (f) => f.category === 'undefined-acronym' && f.message.includes('"PROFANITY"'),
+      );
+      expect(finding).toBeUndefined();
+    });
+
+    it('does not flag VIOLENCE as undefined acronym (suffix -NCE)', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'README.md'),
+        '# Project\n\nContent depicting VIOLENCE is prohibited.\n',
+      );
+
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const finding = findings.find(
+        (f) => f.category === 'undefined-acronym' && f.message.includes('"VIOLENCE"'),
+      );
+      expect(finding).toBeUndefined();
+    });
+
+    // Layer 2 — length threshold suppression
+    it('does not flag SECURITY as undefined acronym (length > 5)', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'README.md'),
+        '# Project\n\nSECURITY is a top priority for this project.\n',
+      );
+
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const finding = findings.find(
+        (f) => f.category === 'undefined-acronym' && f.message.includes('"SECURITY"'),
+      );
+      expect(finding).toBeUndefined();
+    });
+
+    it('does not flag CONTRIBUTING as undefined acronym (length > 5)', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'README.md'),
+        '# Project\n\nSee CONTRIBUTING for guidelines.\n',
+      );
+
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const finding = findings.find(
+        (f) => f.category === 'undefined-acronym' && f.message.includes('"CONTRIBUTING"'),
+      );
+      expect(finding).toBeUndefined();
+    });
+
+    // Layer 3 — vowel ratio suppression
+    it('does not flag PHONE as undefined acronym (length 5, vowel ratio > 0.35)', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'README.md'),
+        '# Project\n\nContact us by PHONE or email.\n',
+      );
+
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const finding = findings.find(
+        (f) => f.category === 'undefined-acronym' && f.message.includes('"PHONE"'),
+      );
+      expect(finding).toBeUndefined();
+    });
+
+    it('does not flag EMAIL as undefined acronym (length 5, vowel ratio > 0.35)', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'README.md'),
+        '# Project\n\nSend your questions to our EMAIL address.\n',
+      );
+
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const finding = findings.find(
+        (f) => f.category === 'undefined-acronym' && f.message.includes('"EMAIL"'),
+      );
+      expect(finding).toBeUndefined();
+    });
+
+    // Genuine short acronyms must still be flagged
+    it('still flags JWT as a potential undefined acronym', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'README.md'),
+        '# Project\n\nAuthentication uses JWT for session management.\n',
+      );
+
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const finding = findings.find(
+        (f) => f.category === 'undefined-acronym' && f.message.includes('"JWT"'),
+      );
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe(Severity.INFO);
+    });
+
+    it('still flags RLHF as a potential undefined acronym', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'README.md'),
+        '# Project\n\nThe model was fine-tuned with RLHF.\n',
+      );
+
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const finding = findings.find(
+        (f) => f.category === 'undefined-acronym' && f.message.includes('"RLHF"'),
+      );
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe(Severity.INFO);
+    });
+  });
 });

--- a/tests/scanner/inclusive/term-list.test.ts
+++ b/tests/scanner/inclusive/term-list.test.ts
@@ -63,6 +63,12 @@ describe('TermListManager', () => {
         expect(term.replacements.length).toBeGreaterThan(0);
       }
     });
+
+    it('end-of-life term has per-term INI referenceUrl', () => {
+      const eol = BUNDLED_TERMS.find((t) => t.term === 'end-of-life');
+      expect(eol).toBeDefined();
+      expect(eol!.referenceUrl).toBe('https://inclusivenaming.org/word-lists/tier-3/end-of-life/');
+    });
   });
 
   describe('loadTerms()', () => {


### PR DESCRIPTION
## Summary

Closes #192.

- Replaces dictionary-expansion as the primary false-positive mechanism with three deterministic heuristics: morphological suffix check (`-ED`, `-ITY`, `-NCE`, etc.), length threshold (>5 chars = word, not initialism), and vowel-ratio check (≥4 chars with >35% vowels = word).
- `COMMON_ENGLISH_WORDS` retained as a fast-path cache; no longer the only safety net.
- All confirmed false positives suppressed: PROFANITY, VIOLENCE, REDACTED, PHONE, EMAIL.
- Genuine short acronyms (JWT, RLHF, CRUD, LLM, MCP) still flagged correctly.
- Also adds `referenceUrl` for `end-of-life` term per INI tier-3 page.

## Test plan

- [x] Red tests: each false-positive token tested individually (`tests/scanner/inclusive/assumed-knowledge-scanner.test.ts`)
- [x] `npm run test:coverage` green, 97.62% overall (≥80%)
- [x] TypeScript build clean (`npm run build` — no errors)
- [x] PRD update: n/a (bug fix to existing scanner)
- [x] README update: no
