### PR TITLE
fix: skip code fences in prose checks (assumed-knowledge scanner) (#194)

### DIFF
--- a/src/scanner/inclusive/assumed-knowledge-scanner.ts
+++ b/src/scanner/inclusive/assumed-knowledge-scanner.ts
@@ -12,6 +12,7 @@ import { Pillar, Severity } from '../../types/index.js';
 import type { Scanner, ScanContext, Finding } from '../../types/index.js';
 import { loadIgnorePatterns } from './ignore-file.js';
 import { COMMON_ENGLISH_WORDS } from './data/common-english-words.js';
+import { stripCodeFences } from './utils/strip-code-fences.js';
 
 /** Files to scan for assumed knowledge. */
 const TARGET_FILES: string[] = [
@@ -165,11 +166,12 @@ export class AssumedKnowledgeScanner implements Scanner {
       }
 
       const content = fs.readFileSync(absPath, 'utf-8');
-      const lines = content.split('\n');
+      const proseContent = stripCodeFences(content);
+      const proseLines = proseContent.split('\n');
 
-      findings.push(...this.detectGitOperations(relPath, lines));
-      findings.push(...this.detectToolAssumptions(relPath, lines, content));
-      findings.push(...this.detectUndefinedAcronyms(relPath, lines));
+      findings.push(...this.detectGitOperations(relPath, proseLines));
+      findings.push(...this.detectToolAssumptions(relPath, proseLines, proseContent));
+      findings.push(...this.detectUndefinedAcronyms(relPath, proseLines));
     }
 
     // Check README.md for missing prerequisites section

--- a/src/scanner/inclusive/utils/strip-code-fences.ts
+++ b/src/scanner/inclusive/utils/strip-code-fences.ts
@@ -1,0 +1,22 @@
+/**
+ * Replaces fenced code blocks and inline code in a markdown string with blank
+ * content of the same length so that line numbers remain stable. Used by prose
+ * scanners (assumed-knowledge, diminishing) that must not analyse code samples.
+ *
+ * INI naming-term scanners must NOT use this — `abort`, `whitelist`, etc. must
+ * still be flagged inside code fences where they appear as real identifiers.
+ */
+export function stripCodeFences(content: string): string {
+  // Replace fenced blocks (``` ... ```) — preserve newlines so line numbers stay correct
+  let stripped = content.replace(/^```[\s\S]*?^```[ \t]*$/gm, (match) =>
+    match
+      .split('\n')
+      .map(() => '')
+      .join('\n'),
+  );
+
+  // Replace inline code (`...`) with spaces of equal length
+  stripped = stripped.replace(/`[^`\n]+`/g, (m) => ' '.repeat(m.length));
+
+  return stripped;
+}

--- a/tests/scanner/inclusive/assumed-knowledge-scanner.test.ts
+++ b/tests/scanner/inclusive/assumed-knowledge-scanner.test.ts
@@ -84,7 +84,7 @@ describe('AssumedKnowledgeScanner', () => {
     it('detects "git clone" as assumed knowledge', async () => {
       fs.writeFileSync(
         path.join(tmpDir, 'README.md'),
-        '# Project\n\nTo get started:\n\n```\ngit clone https://github.com/org/repo.git\n```\n',
+        '# Project\n\nTo get started, git clone https://github.com/org/repo.git.\n',
       );
 
       const context = createContext(tmpDir);
@@ -135,7 +135,7 @@ describe('AssumedKnowledgeScanner', () => {
     it('detects "npm install" without prerequisites section', async () => {
       fs.writeFileSync(
         path.join(tmpDir, 'README.md'),
-        '# Project\n\n## Getting Started\n\nRun `npm install` to install dependencies.\n',
+        '# Project\n\n## Getting Started\n\nRun npm install to install dependencies.\n',
       );
 
       const context = createContext(tmpDir);
@@ -151,7 +151,7 @@ describe('AssumedKnowledgeScanner', () => {
     it('detects "pip install" without prerequisites section', async () => {
       fs.writeFileSync(
         path.join(tmpDir, 'README.md'),
-        '# Project\n\n## Setup\n\nRun `pip install -r requirements.txt`.\n',
+        '# Project\n\n## Setup\n\nRun pip install -r requirements.txt.\n',
       );
 
       const context = createContext(tmpDir);
@@ -166,7 +166,7 @@ describe('AssumedKnowledgeScanner', () => {
     it('detects "docker run" without prerequisites section', async () => {
       fs.writeFileSync(
         path.join(tmpDir, 'README.md'),
-        '# Project\n\n## Running\n\n```\ndocker run -p 3000:3000 myapp\n```\n',
+        '# Project\n\n## Running\n\ndocker run -p 3000:3000 myapp\n',
       );
 
       const context = createContext(tmpDir);
@@ -229,7 +229,7 @@ describe('AssumedKnowledgeScanner', () => {
     it('flags missing Prerequisites section when commands are present', async () => {
       fs.writeFileSync(
         path.join(tmpDir, 'README.md'),
-        '# Project\n\n## Getting Started\n\nRun `npm install` then `npm start`.\n',
+        '# Project\n\n## Getting Started\n\nRun npm install then npm start.\n',
       );
 
       const context = createContext(tmpDir);
@@ -541,7 +541,7 @@ describe('AssumedKnowledgeScanner', () => {
       fs.writeFileSync(path.join(tmpDir, 'README.md'), '# Clean\n');
       fs.writeFileSync(
         path.join(tmpDir, 'CONTRIBUTING.md'),
-        '# Contributing\n\nRun `npm install` first.\n',
+        '# Contributing\n\nRun npm install first.\n',
       );
       const context = createContext(tmpDir);
       context.config.inclusive = {
@@ -769,6 +769,134 @@ describe('AssumedKnowledgeScanner', () => {
       );
       expect(finding).toBeDefined();
       expect(finding!.severity).toBe(Severity.INFO);
+    });
+  });
+
+  describe('code fence skipping (#194)', () => {
+    it('does not flag acronyms inside fenced code blocks', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'README.md'),
+        [
+          '# Project',
+          '',
+          'Content moderation categories:',
+          '',
+          '```typescript',
+          'const categories = {',
+          '  PROFANITY: true,',
+          '  VIOLENCE: false,',
+          '  EMAIL: true,',
+          '  PHONE: false,',
+          '  REDACTED: false,',
+          '};',
+          '```',
+          '',
+          'See above for the full list.',
+        ].join('\n'),
+      );
+
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const codeFenceAcronyms = findings.filter(
+        (f) =>
+          f.category === 'undefined-acronym' &&
+          /PROFANITY|VIOLENCE|EMAIL|PHONE|REDACTED/.test(f.message),
+      );
+      expect(codeFenceAcronyms).toHaveLength(0);
+    });
+
+    it('does not flag tool commands inside fenced code blocks', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'README.md'),
+        [
+          '# Quickstart',
+          '',
+          'Run the following:',
+          '',
+          '```sh',
+          'npm install',
+          'npm run build',
+          'npm test',
+          '```',
+        ].join('\n'),
+      );
+
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const codeFenceTools = findings.filter(
+        (f) => f.category === 'assumed-knowledge' && f.id.startsWith('AK-TOOL-NPM'),
+      );
+      expect(codeFenceTools).toHaveLength(0);
+    });
+
+    it('does not flag git operations inside fenced code blocks', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'README.md'),
+        [
+          '# Development',
+          '',
+          'To get the code:',
+          '',
+          '```sh',
+          'git clone https://github.com/example/repo',
+          'git checkout -b my-feature',
+          '```',
+        ].join('\n'),
+      );
+
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const codeFenceGit = findings.filter(
+        (f) =>
+          f.category === 'assumed-knowledge' &&
+          (f.id.includes('AK-GIT-CLONE') || f.id.includes('AK-GIT-BRANCH')),
+      );
+      expect(codeFenceGit).toHaveLength(0);
+    });
+
+    it('still flags acronyms in prose after a code block', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'README.md'),
+        [
+          '# Project',
+          '',
+          '```sh',
+          'npm install',
+          '```',
+          '',
+          'The project uses RLHF for fine-tuning.',
+        ].join('\n'),
+      );
+
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const rlhfFinding = findings.find(
+        (f) => f.category === 'undefined-acronym' && f.message.includes('"RLHF"'),
+      );
+      expect(rlhfFinding).toBeDefined();
+    });
+
+    it('does not flag acronyms inside inline code', async () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'README.md'),
+        [
+          '# Project',
+          '',
+          'Call the `PROFANITY_CHECK` function to validate input.',
+        ].join('\n'),
+      );
+
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const inlineAcronym = findings.filter(
+        (f) => f.category === 'undefined-acronym' && f.message.includes('"PROFANITY_CHECK"'),
+      );
+      expect(inlineAcronym).toHaveLength(0);
     });
   });
 });

--- a/tests/scanner/inclusive/strip-code-fences.test.ts
+++ b/tests/scanner/inclusive/strip-code-fences.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { stripCodeFences } from '../../../src/scanner/inclusive/utils/strip-code-fences.js';
+
+describe('stripCodeFences', () => {
+  it('preserves plain prose unchanged', () => {
+    const input = 'Hello world\nThis is prose.\n';
+    expect(stripCodeFences(input)).toBe(input);
+  });
+
+  it('replaces fenced code block content with blank lines', () => {
+    const input = 'Prose before\n```\nconst x = PROFANITY;\n```\nProse after\n';
+    const result = stripCodeFences(input);
+    expect(result).toContain('Prose before');
+    expect(result).toContain('Prose after');
+    expect(result).not.toContain('PROFANITY');
+  });
+
+  it('preserves line count so line numbers stay correct', () => {
+    const input = 'Line 1\n```\nLine 3\nLine 4\n```\nLine 6\n';
+    const result = stripCodeFences(input);
+    expect(result.split('\n')).toHaveLength(input.split('\n').length);
+  });
+
+  it('replaces inline code with spaces', () => {
+    const input = 'Call the `PROFANITY_CHECK` function.\n';
+    const result = stripCodeFences(input);
+    expect(result).not.toContain('PROFANITY_CHECK');
+    expect(result.length).toBe(input.length);
+  });
+
+  it('handles fenced block with language hint', () => {
+    const input = '```typescript\nconst VIOLENCE = true;\n```\n';
+    const result = stripCodeFences(input);
+    expect(result).not.toContain('VIOLENCE');
+  });
+
+  it('does not touch prose between blocks', () => {
+    const input = [
+      'Intro prose.',
+      '```sh',
+      'npm install',
+      '```',
+      'Middle prose.',
+      '```',
+      'docker run',
+      '```',
+      'End prose.',
+    ].join('\n');
+    const result = stripCodeFences(input);
+    expect(result).toContain('Intro prose.');
+    expect(result).toContain('Middle prose.');
+    expect(result).toContain('End prose.');
+    expect(result).not.toContain('npm install');
+    expect(result).not.toContain('docker run');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #194.

Acronym, git-op, and tool-command detections in `assumed-knowledge-scanner` were running on raw markdown content including fenced code blocks and inline code. This caused false positives: enum constants like `PROFANITY` or `VIOLENCE` in a code sample were flagged as undefined acronyms; `npm install` inside a ` ``` ` block was flagged as assumed knowledge.

Adds `src/scanner/inclusive/utils/strip-code-fences.ts` — replaces fenced blocks and inline code with blank content of equal length (preserving line numbers), then passes prose content to all three prose detectors. INI naming checks in `doc-scanner` and `code-scanner` are intentionally not affected: `abort`, `whitelist`, etc. must still be flagged inside code fences.

Note: `diminishing-scanner` already had equivalent `getCodeBlockLines()` logic — no change needed there.

## Test plan

- [x] Red tests confirmed failing before implementation (5 new tests: no acronyms/tools/git in fenced blocks, prose after block still flagged, no inline-code acronyms)
- [x] 6 existing tests updated to use prose fixtures (old fixtures accidentally tested buggy behavior — commands in code fences that were incorrectly flagged)
- [x] 6 new unit tests for `stripCodeFences` utility directly
- [x] `npm run test:coverage` green — 1628 passed, 97.62% coverage
- [x] README update: no user-facing change to document