### PR TITLE
feat: grouped markdown rendering — collapse repeat findings (#196)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ export { DEFAULT_CONFIG, buildConfig, validateTarget } from './config.js';
 // Reporters
 export { buildScanReport, serializeJson } from './reporters/json.js';
 export { renderMarkdown } from './reporters/markdown.js';
+export type { MarkdownReportOptions } from './reporters/markdown.js';
 export { renderTrendAscii, alertOnDrop } from './reporters/trend.js';
 
 // Issue helpers

--- a/src/reporters/markdown.ts
+++ b/src/reporters/markdown.ts
@@ -103,6 +103,99 @@ export interface MarkdownReportOptions {
     language?: string;
     stars?: number;
   };
+  /** Collapse repeat-message findings into one entry with count + file list. Applies to Warnings and Info only. */
+  grouped?: boolean;
+}
+
+interface FindingGroup {
+  key: string;
+  representative: Finding;
+  members: Finding[];
+}
+
+/**
+ * Normalise a finding message into a canonical group key by stripping
+ * occurrence-specific details (context suffix, package version, etc.).
+ */
+function canonicalKey(f: Finding): string {
+  const msg = f.message;
+
+  // "Non-inclusive term "X" found in <context>" → "Non-inclusive term "X""
+  const iniMatch = msg.match(/^(Non-inclusive term "[^"]+"|Found diminishing language "[^"]+")/);
+  if (iniMatch) return iniMatch[1];
+
+  // "Loosely pinned dependency "pkg": "^x.y.z" uses ^ prefix in devDependencies/..." → canonical
+  if (/Loosely pinned dependency .* uses \^ prefix in devDependencies/.test(msg)) {
+    return 'Loosely pinned devDependencies (^ prefix)';
+  }
+  if (/Loosely pinned dependency .* uses \^ prefix in/.test(msg)) {
+    return 'Loosely pinned dependency (^ prefix)';
+  }
+  if (/Loosely pinned dependency .* uses ~ prefix in devDependencies/.test(msg)) {
+    return 'Loosely pinned devDependencies (~ prefix)';
+  }
+
+  // "Undefined acronym "X" may confuse newcomers" → "Undefined acronym "X""
+  const acronymMatch = msg.match(/^(Undefined acronym "[^"]+")/);
+  if (acronymMatch) return acronymMatch[1];
+
+  // "Assumed knowledge: "X" command used without ..." → "Assumed knowledge: "X" command"
+  const akMatch = msg.match(/^(Assumed knowledge: "[^"]+" (?:command|operation))/);
+  if (akMatch) return akMatch[1];
+
+  // Fallback: use the full message as key (no grouping unless identical)
+  return msg;
+}
+
+function groupFindings(findings: Finding[]): FindingGroup[] {
+  const map = new Map<string, FindingGroup>();
+
+  for (const f of findings) {
+    const key = canonicalKey(f);
+    const existing = map.get(key);
+    if (existing) {
+      existing.members.push(f);
+    } else {
+      map.set(key, { key, representative: f, members: [f] });
+    }
+  }
+
+  return [...map.values()];
+}
+
+/** Render a grouped finding entry for Warnings/Info sections. */
+function renderGroupedFinding(group: FindingGroup): string[] {
+  const { key, representative: rep, members } = group;
+  const lines: string[] = [];
+
+  if (members.length === 1) {
+    // Single occurrence — render exactly as before
+    lines.push(`- **[${rep.id}]** ${tierPrefix(rep)}${rep.message} *(${rep.suggestion})*`);
+    return lines;
+  }
+
+  // Multi-occurrence grouped entry
+  const tierLabel = tierPrefix(rep);
+  const tierSuffix = tierLabel ? ` ${tierLabel.trim()}` : '';
+  lines.push(`- **[${rep.pillar}] ${key}** — ${members.length} occurrences${tierSuffix}`);
+
+  const extras: string[] = [];
+  if (rep.suggestion) extras.push(`  Replace with: ${rep.suggestion}`);
+  if (rep.referenceUrl) extras.push(`· [Reference](${rep.referenceUrl})`);
+  if (extras.length > 0) lines.push(`  ${extras.join(' ')}`);
+
+  // File:line refs — show first 5, then "+N more"
+  const MAX_REFS = 5;
+  const withFile = members.filter((m) => m.file);
+  const refs = withFile.slice(0, MAX_REFS).map((m) => {
+    const loc = m.line ? `${m.file}:${m.line}` : m.file!;
+    const ctx = m.context ? ` (${m.context})` : '';
+    return `\`${loc}\`${ctx}`;
+  });
+  if (withFile.length > MAX_REFS) refs.push(`_+${withFile.length - MAX_REFS} more_`);
+  if (refs.length > 0) lines.push(`  ${refs.join(' · ')}`);
+
+  return lines;
 }
 
 export function renderMarkdown(report: ScanReport, options?: MarkdownReportOptions): string {
@@ -173,8 +266,14 @@ export function renderMarkdown(report: ScanReport, options?: MarkdownReportOptio
   if (realWarnings.length > 0) {
     lines.push('## Warnings');
     lines.push('');
-    for (const f of realWarnings) {
-      lines.push(`- **[${f.id}]** ${tierPrefix(f)}${f.message} *(${f.suggestion})*`);
+    if (options?.grouped) {
+      for (const group of groupFindings(realWarnings)) {
+        for (const line of renderGroupedFinding(group)) lines.push(line);
+      }
+    } else {
+      for (const f of realWarnings) {
+        lines.push(`- **[${f.id}]** ${tierPrefix(f)}${f.message} *(${f.suggestion})*`);
+      }
     }
     lines.push('');
   }
@@ -203,8 +302,21 @@ export function renderMarkdown(report: ScanReport, options?: MarkdownReportOptio
   if (infos.length > 0) {
     lines.push('## Info');
     lines.push('');
-    for (const f of infos) {
-      lines.push(`- **[${f.id}]** ${tierPrefix(f)}${f.message}`);
+    if (options?.grouped) {
+      for (const group of groupFindings(infos)) {
+        for (const line of renderGroupedFinding(group)) {
+          // Info ungrouped format omits suggestion; grouped format includes it inline
+          if (group.members.length === 1) {
+            lines.push(`- **[${group.representative.id}]** ${tierPrefix(group.representative)}${group.representative.message}`);
+          } else {
+            lines.push(line);
+          }
+        }
+      }
+    } else {
+      for (const f of infos) {
+        lines.push(`- **[${f.id}]** ${tierPrefix(f)}${f.message}`);
+      }
     }
     lines.push('');
   }

--- a/tests/reporters/markdown.test.ts
+++ b/tests/reporters/markdown.test.ts
@@ -1023,4 +1023,130 @@ describe('renderMarkdown', () => {
       expect(md).toContain('scorecard');
     });
   });
+
+  describe('grouped rendering (#196)', () => {
+    function makeAbortFindings(count: number): Finding[] {
+      return Array.from({ length: count }, (_, i) => ({
+        id: `INC-NAMING-abort-src/client.ts:${i + 1}`,
+        severity: Severity.WARNING,
+        pillar: Pillar.INCLUSIVE,
+        category: 'non-inclusive-term',
+        message: `Non-inclusive term "abort" found in string literal`,
+        file: `src/client.ts`,
+        line: i + 1,
+        column: 1,
+        suggestion: 'Replace with: cancel, terminate, stop, halt',
+        referenceUrl: 'https://inclusivenaming.org/word-lists/tier-1/abort/',
+        dataSource: 'local' as const,
+        metadata: { tier: 1 as const },
+      }));
+    }
+
+    it('collapses repeat-message warnings into one grouped entry when grouped: true', () => {
+      const findings = makeAbortFindings(11);
+      const report = makeReport(findings);
+      const md = renderMarkdown(report, { grouped: true });
+
+      // Should be one grouped entry for abort, not 11 separate bullets
+      const abortMatches = [...md.matchAll(/Non-inclusive term "abort"/g)];
+      expect(abortMatches.length).toBe(1);
+      expect(md).toContain('11 occurrences');
+    });
+
+    it('shows up to 5 file:line refs then "+N more" for large groups', () => {
+      const findings = makeAbortFindings(11);
+      const report = makeReport(findings);
+      const md = renderMarkdown(report, { grouped: true });
+
+      expect(md).toContain('+6 more');
+    });
+
+    it('renders single-occurrence findings unchanged', () => {
+      const findings: Finding[] = [
+        {
+          id: 'gov-01',
+          severity: Severity.WARNING,
+          pillar: Pillar.GOVERNANCE,
+          category: 'license',
+          message: 'No license file found',
+          file: null,
+          line: null,
+          column: null,
+          suggestion: 'Add a LICENSE file',
+        },
+      ];
+      const report = makeReport(findings);
+      const md = renderMarkdown(report, { grouped: true });
+
+      // Single finding renders normally (no "occurrences" count)
+      expect(md).toContain('No license file found');
+      expect(md).not.toContain('occurrences');
+    });
+
+    it('groups devDependency pin findings under a canonical key', () => {
+      const devDepFindings: Finding[] = [
+        '@changesets/cli', '@types/node', 'vitest',
+      ].map((pkg, i) => ({
+        id: `SEC-DEP-PIN-${pkg}`,
+        severity: Severity.INFO,
+        pillar: Pillar.SECURITY,
+        category: 'dep-pinning',
+        message: `Loosely pinned dependency "${pkg}": "^2.${i}.0" uses ^ prefix in devDependencies`,
+        file: 'package.json',
+        line: 10 + i,
+        column: 1,
+        suggestion: 'Pin to exact version',
+        dataSource: 'local' as const,
+      }));
+      const report = makeReport(devDepFindings);
+      const md = renderMarkdown(report, { grouped: true });
+
+      expect(md).toContain('3 occurrences');
+      // Should not show all 3 package names as separate bullets
+      const pkgMatches = [...md.matchAll(/Loosely pinned/g)];
+      expect(pkgMatches.length).toBe(1);
+    });
+
+    it('does NOT group critical findings — they keep full-detail rendering', () => {
+      const findings: Finding[] = Array.from({ length: 3 }, (_, i) => ({
+        id: `SEC-CRIT-${i}`,
+        severity: Severity.CRITICAL,
+        pillar: Pillar.SECURITY,
+        category: 'secret-exposure',
+        message: 'Hardcoded secret detected',
+        file: `src/file${i}.ts`,
+        line: 1,
+        column: 1,
+        suggestion: 'Remove and rotate this secret',
+      }));
+      const report = makeReport(findings);
+      const md = renderMarkdown(report, { grouped: true });
+
+      // All 3 criticals render individually under ## Critical Findings
+      expect(md).toContain('SEC-CRIT-0');
+      expect(md).toContain('SEC-CRIT-1');
+      expect(md).toContain('SEC-CRIT-2');
+      expect(md).not.toContain('3 occurrences');
+    });
+
+    it('ungrouped mode (grouped: false or omitted) renders same as before', () => {
+      const findings = makeAbortFindings(3);
+      const report = makeReport(findings);
+      const ungrouped = renderMarkdown(report);
+      const explicit = renderMarkdown(report, { grouped: false });
+
+      expect(ungrouped).toBe(explicit);
+      // All 3 findings have their own ID bullets
+      expect([...ungrouped.matchAll(/INC-NAMING-abort/g)].length).toBe(3);
+    });
+
+    it('includes the suggestion and referenceUrl in the grouped entry', () => {
+      const findings = makeAbortFindings(3);
+      const report = makeReport(findings);
+      const md = renderMarkdown(report, { grouped: true });
+
+      expect(md).toContain('Replace with: cancel, terminate, stop, halt');
+      expect(md).toContain('https://inclusivenaming.org/word-lists/tier-1/abort/');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes #196.

Adds `grouped: true` option to `renderMarkdown` that collapses repeat-message findings into a single human-readable entry with an occurrence count and file:line list. Addresses the problem where repos like ai-kit produce 30+ identical "Non-inclusive term 'abort'" lines in the Warnings section.

- **Criticals:** unchanged — always render full-detail per finding
- **Warnings and Info:** when `grouped: true`, findings with the same canonical message are collapsed into one entry showing count + first 5 refs (`+N more` for large groups)
- **Count = 1:** renders exactly as before (no change)
- **`grouped: false` or omitted:** identical output to current behavior

Canonical key normalisation covers: INI terms, diminishing language, devDep pins, undefined acronyms, assumed-knowledge tool commands.

Also exports `MarkdownReportOptions` type from the library entrypoint.

## Test plan

- [x] Red tests confirmed failing (4 new tests)
- [x] 74 markdown reporter tests pass
- [x] `npm run test:coverage` green — 1635 passed, 97.59%
- [x] README: no user-facing change yet (batch script update is a follow-on)