### PR TITLE
feat: self-contained HTML report renderer (Story 8.8)

### DIFF
--- a/docs/PRD-v2.md
+++ b/docs/PRD-v2.md
@@ -1,4 +1,4 @@
-# Quaid's OSS Repo Scanner - PRD v2.6
+# Quaid's OSS Repo Scanner - PRD v2.7
 
 ## Executive Summary
 
@@ -2074,6 +2074,53 @@ quaid-scanner . --format json --quiet --provenance-file /tmp/provenance.json
 
 ---
 
+### Story 8.8: Self-Contained HTML Report Renderer (HTML-01) 📋
+
+**As a** Human reviewer
+**I want** a beautiful self-contained HTML report I can open in any browser
+**So that** I can review repo health without needing a terminal or markdown renderer
+
+**Acceptance Criteria:**
+
+| # | Criterion | Verification |
+|---|-----------|--------------|
+| 8.8.1 | `renderHtml(report, options?)` exported from `src/index.ts` | TypeScript compilation |
+| 8.8.2 | Output is a valid, fully self-contained HTML document (no external `<link>` or `<script src>`) | Self-contained test |
+| 8.8.3 | JSON scan data embedded as `<script id="scan-data" type="application/json">` | JSON embed test |
+| 8.8.4 | Score ring (SVG), 6-pillar card grid, and severity-grouped findings sections rendered | Visual structure check |
+| 8.8.5 | `grouped: true` collapses repeat-message findings identically to the markdown renderer | Grouped rendering test |
+| 8.8.6 | `prefers-color-scheme: dark` alternate palette present in inline CSS | CSS test |
+| 8.8.7 | `groupFindings()` and `canonicalKey()` extracted to `src/reporters/utils.ts` and imported by both renderers | Refactor — markdown tests still green |
+| 8.8.8 | `npm run test:coverage` ≥ 80% statements and branches | Coverage gate |
+
+**Story Points:** 3
+**Milestone:** 0.1.4
+**Issues:** #198
+
+---
+
+### Story 8.9: Scan Scripts Write HTML by Default (HTML-02) 📋
+
+**As a** Scan operator (human or agent)
+**I want** every scan to produce a `.html` alongside the `.md` and `.json`
+**So that** human reviewers always have a browser-ready artifact without an extra render step
+
+**Acceptance Criteria:**
+
+| # | Criterion | Verification |
+|---|-----------|--------------|
+| 8.9.1 | `quaid-scan-one.mjs <repo>` writes `quaid-scan-DATE.json`, `.md`, and `.html` | File existence check |
+| 8.9.2 | `quaid-render-one.mjs <repo>` (no flag) renders both `.md` and `.html` | File existence check |
+| 8.9.3 | `quaid-render-one.mjs <repo> --format html` renders `.html` only | Format flag test |
+| 8.9.4 | `quaid-render-one.mjs <repo> --format md` renders `.md` only | Format flag test |
+| 8.9.5 | Existing `.md` and `.json` write paths unchanged | Regression check |
+
+**Story Points:** 1
+**Milestone:** 0.1.4
+**Issues:** #199
+
+---
+
 ## Epic 10: Ecosystem Intelligence
 
 Strategic analysis of the competitive and cooperative OSS landscape. **Not a scored pillar** — does not affect `overallScore`. Opt-in via `--ecosystem` flag.
@@ -2570,7 +2617,7 @@ quaid-scanner/
 | Epic 5: AI-Native | 6 | 13 | Model Cards, Multi-Model Agentic Rules | 🚧 Partial (5.4 Metadata Quality) |
 | Epic 6: Inclusive | 5+1 | 14 | INI Terms, Naming, Diminishing Language | 🚧 Partial (6.1a INI API caching) |
 | Epic 7: Technical | 5 | 11 | Linting, Coverage, Release Vitality | ✅ Done |
-| Epic 8: Reporting | 7 | 16 | JSON/Markdown, Historical Trends, Report Provenance | 🚧 Partial (8.7a/b/c planned) |
+| Epic 8: Reporting | 9 | 20 | JSON/Markdown/HTML, Historical Trends, Report Provenance | 🚧 Partial (8.7–8.9 planned) |
 | Epic 9: Claude Integration | 2 | 5 | SKILL.md, MCP Server | ✅ Done |
 | Epic 10: Ecosystem Intelligence | 6 | 13 | Rivals, Partners, Communities, Strategy | ✅ Done |
 | Epic 11: Cross-Validation Harness | 4 | 9 | OpenSSF, licensee, accuracy regression CI | 📋 Planned |
@@ -2581,6 +2628,16 @@ quaid-scanner/
 ---
 
 ### Change Log
+
+#### v2.7 Changes (from v2.6)
+
+| Change | Impact |
+|--------|--------|
+| Add Story 8.8: Self-contained HTML report renderer (`renderHtml`) | 📋 Planned — #198; 3 pts |
+| Add Story 8.9: Scan scripts write HTML by default | 📋 Planned — #199; 1 pt |
+| Epic 8: Reporting story count 7 → 9, points 16 → 20 | Status updated to 🚧 Partial |
+| Story total: 75 → 77; Points total: 178 → 182 | |
+| PRD version: v2.6 → v2.7 | |
 
 #### v2.6 Changes (from v2.5)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,8 @@ export { DEFAULT_CONFIG, buildConfig, validateTarget } from './config.js';
 export { buildScanReport, serializeJson } from './reporters/json.js';
 export { renderMarkdown } from './reporters/markdown.js';
 export type { MarkdownReportOptions } from './reporters/markdown.js';
+export { renderHtml } from './reporters/html.js';
+export type { HtmlReportOptions } from './reporters/html.js';
 export { renderTrendAscii, alertOnDrop } from './reporters/trend.js';
 
 // Issue helpers

--- a/src/reporters/html.ts
+++ b/src/reporters/html.ts
@@ -1,0 +1,529 @@
+import { Severity, Pillar, RiskLevel, PILLAR_WEIGHTS } from '../types/index.js';
+import type { ScanReport, Finding } from '../types/index.js';
+import { isErrorFinding } from '../issues.js';
+import { groupFindings, MAX_GROUP_REFS } from './utils.js';
+import type { FindingGroup } from './utils.js';
+
+export interface HtmlReportOptions {
+  ecosystem?: { name: string; language?: string; stars?: number };
+  /** Collapse repeat-message findings into one grouped entry. Applies to Warnings and Info only. */
+  grouped?: boolean;
+  /** Override the HTML page <title>. Defaults to "quaid-scanner: {repo}". */
+  title?: string;
+}
+
+// ── Display mappings ──────────────────────────────────────────────────────────
+
+const PILLAR_LABELS: Record<Pillar, string> = {
+  [Pillar.SECURITY]: 'Security',
+  [Pillar.GOVERNANCE]: 'Governance',
+  [Pillar.COMMUNITY]: 'Community',
+  [Pillar.AI_READINESS]: 'AI Readiness',
+  [Pillar.INCLUSIVE]: 'Inclusive',
+  [Pillar.TECHNICAL]: 'Technical',
+};
+
+const PILLAR_ICONS: Record<Pillar, string> = {
+  [Pillar.SECURITY]: '🔒',
+  [Pillar.GOVERNANCE]: '📋',
+  [Pillar.COMMUNITY]: '🤝',
+  [Pillar.AI_READINESS]: '🤖',
+  [Pillar.INCLUSIVE]: '🌱',
+  [Pillar.TECHNICAL]: '⚙️',
+};
+
+const RISK_COLOR: Record<RiskLevel, string> = {
+  [RiskLevel.LOW]: 'var(--pass)',
+  [RiskLevel.MEDIUM]: 'var(--warning)',
+  [RiskLevel.HIGH]: '#ea580c',
+  [RiskLevel.CRITICAL]: 'var(--critical)',
+};
+
+const SEVERITY_LABELS: Record<number, string> = {
+  [Severity.PASS]: 'PASS',
+  [Severity.INFO]: 'INFO',
+  [Severity.WARNING]: 'WARNING',
+  [Severity.CRITICAL]: 'CRITICAL',
+};
+
+const INI_TIER_LABELS: Record<1 | 2 | 3, string> = {
+  1: 'Tier 1 — Replace Immediately',
+  2: 'Tier 2 — Strongly Consider',
+  3: 'Tier 3 — Recommended',
+};
+
+// ── Utilities ─────────────────────────────────────────────────────────────────
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function findingsBySeverity(findings: Finding[], severity: Severity): Finding[] {
+  return findings.filter((f) => f.severity === severity);
+}
+
+function tierBadge(f: Finding): string {
+  const tier = f.metadata?.tier;
+  if (tier === 1 || tier === 2 || tier === 3) {
+    return `<span class="tier-badge">${INI_TIER_LABELS[tier]}</span>`;
+  }
+  return '';
+}
+
+// ── Score ring SVG (pure SVG, no JS) ─────────────────────────────────────────
+
+function scoreRing(score: number, riskLevel: RiskLevel): string {
+  const r = 52;
+  const circumference = 2 * Math.PI * r; // ≈ 326.7
+  const filled = (score / 10) * circumference;
+  const color = RISK_COLOR[riskLevel];
+  const displayScore = score.toFixed(1);
+
+  return `
+    <svg class="score-ring" viewBox="0 0 120 120" width="120" height="120" aria-label="Score ${displayScore} out of 10">
+      <circle cx="60" cy="60" r="${r}" fill="none" stroke="var(--border)" stroke-width="10"/>
+      <circle cx="60" cy="60" r="${r}" fill="none"
+        stroke="${color}" stroke-width="10"
+        stroke-dasharray="${filled.toFixed(1)} ${(circumference - filled).toFixed(1)}"
+        stroke-dashoffset="${(-circumference * 0.25).toFixed(1)}"
+        stroke-linecap="round"/>
+      <text x="60" y="56" text-anchor="middle" dominant-baseline="central"
+            font-size="22" font-weight="700" fill="var(--text)">${displayScore}</text>
+      <text x="60" y="76" text-anchor="middle" dominant-baseline="central"
+            font-size="10" fill="var(--muted)">/10</text>
+    </svg>`;
+}
+
+// ── Pillar grid ───────────────────────────────────────────────────────────────
+
+function pillarCard(pillar: Pillar, report: ScanReport): string {
+  const p = report.pillars[pillar];
+  const pct = Math.min(100, (p.score / 10) * 100).toFixed(0);
+  const { critical, warning, info } = p.counts;
+  const scoreColor = p.score >= 7 ? 'var(--pass)' : p.score >= 4 ? 'var(--warning)' : 'var(--critical)';
+
+  return `
+    <div class="pillar-card">
+      <div class="pillar-header">
+        <span class="pillar-icon">${PILLAR_ICONS[pillar]}</span>
+        <span class="pillar-name">${PILLAR_LABELS[pillar]}</span>
+        <span class="pillar-score" style="color:${scoreColor}">${p.score.toFixed(1)}</span>
+      </div>
+      <div class="progress-bar">
+        <div class="progress-fill" style="width:${pct}%;background:${scoreColor}"></div>
+      </div>
+      <div class="pillar-counts">
+        ${critical > 0 ? `<span class="count-critical">${critical}C</span>` : ''}
+        ${warning > 0 ? `<span class="count-warning">${warning}W</span>` : ''}
+        ${info > 0 ? `<span class="count-info">${info}I</span>` : ''}
+        ${critical === 0 && warning === 0 && info === 0 ? '<span class="count-pass">✓ Clean</span>' : ''}
+      </div>
+    </div>`;
+}
+
+// ── Individual finding card (Criticals) ───────────────────────────────────────
+
+function criticalCard(f: Finding): string {
+  const fileRef = f.file
+    ? `<div class="finding-file"><code>${esc(f.file)}${f.line ? `:${f.line}` : ''}</code></div>`
+    : '';
+  const refLink = f.referenceUrl
+    ? `<a class="ref-link" href="${esc(f.referenceUrl)}" target="_blank" rel="noopener">Reference ↗</a>`
+    : '';
+  const ctx = f.context
+    ? `<pre class="finding-context"><code>${esc(f.context)}</code></pre>`
+    : '';
+
+  return `
+    <div class="finding-card critical-card">
+      <div class="finding-id">${esc(f.id)}</div>
+      <div class="finding-message">${esc(f.message)}</div>
+      ${ctx}
+      ${fileRef}
+      <div class="finding-suggestion">💡 ${esc(f.suggestion)}</div>
+      ${refLink}
+      ${tierBadge(f)}
+    </div>`;
+}
+
+// ── Grouped finding row (Warnings / Info) ─────────────────────────────────────
+
+function groupedFindingRow(group: FindingGroup, severity: Severity): string {
+  const { key, representative: rep, members } = group;
+  const sevClass = severity === Severity.WARNING ? 'warning' : 'info';
+
+  if (members.length === 1) {
+    // Single occurrence — render as a plain row
+    const fileChip = rep.file
+      ? `<code class="file-chip">${esc(rep.file)}${rep.line ? `:${rep.line}` : ''}</code>`
+      : '';
+    return `
+      <div class="finding-row ${sevClass}-row">
+        <span class="finding-id-small">${esc(rep.id)}</span>
+        ${tierBadge(rep)}
+        <span class="finding-msg">${esc(rep.message)}</span>
+        ${fileChip}
+        <span class="finding-sugg">${esc(rep.suggestion)}</span>
+      </div>`;
+  }
+
+  // Multi-occurrence grouped row
+  const withFile = members.filter((m) => m.file);
+  const chips = withFile.slice(0, MAX_GROUP_REFS).map((m) => {
+    const loc = m.line ? `${m.file}:${m.line}` : m.file!;
+    return `<code class="file-chip">${esc(loc)}</code>`;
+  });
+  if (withFile.length > MAX_GROUP_REFS) {
+    chips.push(`<span class="more-chip">+${withFile.length - MAX_GROUP_REFS} more</span>`);
+  }
+
+  const refLink = rep.referenceUrl
+    ? ` <a class="ref-link-sm" href="${esc(rep.referenceUrl)}" target="_blank" rel="noopener">↗</a>`
+    : '';
+
+  return `
+    <div class="finding-row ${sevClass}-row grouped-row">
+      <div class="grouped-header">
+        <span class="grouped-pillar">[${esc(rep.pillar)}]</span>
+        <span class="grouped-key">${esc(key)}</span>
+        ${tierBadge(rep)}
+        <span class="grouped-count">${members.length} occurrences</span>
+      </div>
+      <div class="grouped-sugg">${esc(rep.suggestion)}${refLink}</div>
+      <div class="grouped-files">${chips.join(' ')}</div>
+    </div>`;
+}
+
+// ── Inline CSS ────────────────────────────────────────────────────────────────
+
+const INLINE_CSS = `
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --bg:#ffffff;--surface:#f8fafc;--surface2:#f1f5f9;
+  --border:#e2e8f0;--border2:#cbd5e1;
+  --text:#0f172a;--muted:#64748b;--muted2:#94a3b8;
+  --critical:#dc2626;--warning:#d97706;--info:#2563eb;--pass:#16a34a;
+  --radius:8px;--radius-sm:4px;
+  font-family:Inter,system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+  font-size:15px;line-height:1.6;color:var(--text);background:var(--bg);
+}
+@media(prefers-color-scheme:dark){
+  :root{
+    --bg:#0f172a;--surface:#1e293b;--surface2:#263449;
+    --border:#334155;--border2:#475569;
+    --text:#f1f5f9;--muted:#94a3b8;--muted2:#64748b;
+  }
+}
+body{max-width:1100px;margin:0 auto;padding:24px 20px 48px}
+a{color:var(--info);text-decoration:none}
+a:hover{text-decoration:underline}
+code{font-family:'JetBrains Mono','Fira Code','Cascadia Code',monospace;font-size:0.85em;
+     background:var(--surface2);padding:1px 5px;border-radius:3px}
+pre{background:var(--surface2);border:1px solid var(--border);border-radius:var(--radius-sm);
+    padding:12px;overflow:auto;font-size:0.82em}
+
+/* Header */
+.report-header{display:flex;align-items:center;gap:24px;padding:24px;
+  background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);margin-bottom:24px}
+.header-left{flex:1;min-width:0}
+.repo-name{font-size:1.5rem;font-weight:700;margin-bottom:4px;word-break:break-all}
+.repo-meta{font-size:0.85rem;color:var(--muted)}
+.risk-badge{display:inline-flex;align-items:center;gap:6px;padding:4px 10px;
+  border-radius:20px;font-size:0.8rem;font-weight:600;border:1.5px solid currentColor;margin-top:8px}
+.risk-LOW{color:var(--pass)}
+.risk-MEDIUM{color:var(--warning)}
+.risk-HIGH{color:#ea580c}
+.risk-CRITICAL{color:var(--critical)}
+.score-ring{flex-shrink:0}
+
+/* Pillar grid */
+.pillar-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(170px,1fr));gap:12px;margin-bottom:24px}
+.pillar-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);
+  padding:14px;display:flex;flex-direction:column;gap:8px}
+.pillar-header{display:flex;align-items:center;gap:6px}
+.pillar-icon{font-size:1rem}
+.pillar-name{flex:1;font-size:0.82rem;font-weight:600;color:var(--muted)}
+.pillar-score{font-size:1.1rem;font-weight:700}
+.progress-bar{height:5px;background:var(--border);border-radius:3px;overflow:hidden}
+.progress-fill{height:100%;border-radius:3px;transition:width 0.3s}
+.pillar-counts{display:flex;gap:6px;flex-wrap:wrap;font-size:0.75rem;font-weight:600}
+.count-critical{color:var(--critical)}.count-warning{color:var(--warning)}
+.count-info{color:var(--info)}.count-pass{color:var(--pass)}
+
+/* Section */
+.section{margin-bottom:20px}
+.section summary{cursor:pointer;list-style:none;padding:12px 16px;
+  background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);
+  font-weight:600;font-size:0.95rem;display:flex;align-items:center;gap:8px;
+  user-select:none}
+.section summary::-webkit-details-marker{display:none}
+.section[open] summary{border-bottom-left-radius:0;border-bottom-right-radius:0;border-bottom:none}
+.section-body{background:var(--surface);border:1px solid var(--border);
+  border-top:none;border-bottom-left-radius:var(--radius);border-bottom-right-radius:var(--radius);
+  padding:12px}
+.section-count{margin-left:auto;font-size:0.8rem;color:var(--muted);font-weight:400}
+
+/* Critical cards */
+.finding-card{border-left:4px solid;border-radius:var(--radius-sm);
+  padding:12px 14px;margin-bottom:10px;background:var(--bg)}
+.critical-card{border-left-color:var(--critical);background:color-mix(in srgb,var(--critical) 5%,var(--bg))}
+.finding-id{font-family:monospace;font-size:0.78rem;color:var(--muted);margin-bottom:4px}
+.finding-message{font-weight:500;margin-bottom:6px}
+.finding-file{margin-bottom:4px;font-size:0.85rem}
+.finding-suggestion{font-size:0.85rem;color:var(--muted);margin-top:6px}
+.finding-context{margin:8px 0}
+.ref-link{font-size:0.8rem;color:var(--info);margin-top:4px;display:inline-block}
+
+/* Finding rows (Warnings / Info) */
+.finding-row{padding:8px 10px;border-bottom:1px solid var(--border);font-size:0.875rem;display:flex;
+  flex-wrap:wrap;gap:6px;align-items:baseline}
+.finding-row:last-child{border-bottom:none}
+.warning-row{border-left:3px solid var(--warning)}
+.info-row{border-left:3px solid var(--info)}
+.finding-id-small{font-family:monospace;font-size:0.75rem;color:var(--muted);flex-shrink:0}
+.finding-msg{flex:1;min-width:200px}
+.finding-sugg{font-size:0.8rem;color:var(--muted);width:100%}
+.file-chip{background:var(--surface2);padding:1px 6px;border-radius:3px;font-size:0.78rem}
+.more-chip{font-size:0.78rem;color:var(--muted);font-style:italic}
+
+/* Grouped rows */
+.grouped-row{flex-direction:column;gap:4px}
+.grouped-header{display:flex;flex-wrap:wrap;gap:6px;align-items:center;font-weight:500}
+.grouped-pillar{font-size:0.75rem;color:var(--muted);font-family:monospace}
+.grouped-key{flex:1;min-width:180px}
+.grouped-count{font-size:0.8rem;color:var(--muted);background:var(--surface2);
+  padding:1px 8px;border-radius:10px;flex-shrink:0}
+.grouped-sugg{font-size:0.8rem;color:var(--muted)}
+.grouped-files{display:flex;flex-wrap:wrap;gap:4px;margin-top:2px}
+.ref-link-sm{color:var(--info);font-size:0.8rem}
+
+/* Tier badge */
+.tier-badge{display:inline-block;font-size:0.72rem;background:color-mix(in srgb,var(--warning) 15%,transparent);
+  color:var(--warning);border:1px solid color-mix(in srgb,var(--warning) 30%,transparent);
+  padding:1px 7px;border-radius:10px;font-weight:600}
+
+/* Callouts */
+.callout{border-radius:var(--radius);padding:12px 16px;margin-bottom:16px;font-size:0.875rem}
+.callout-amber{background:color-mix(in srgb,var(--warning) 10%,var(--bg));
+  border:1px solid color-mix(in srgb,var(--warning) 30%,transparent)}
+
+/* Recommendations */
+.rec-list{list-style:none;display:flex;flex-direction:column;gap:8px;padding:4px 0}
+.rec-item{display:flex;gap:10px;align-items:flex-start;padding:10px;
+  background:var(--bg);border:1px solid var(--border);border-radius:var(--radius-sm)}
+.rec-priority{font-size:0.75rem;font-weight:700;color:var(--muted);min-width:20px;padding-top:2px}
+.rec-action{flex:1}
+.impact-badge,.effort-badge{display:inline-block;font-size:0.72rem;font-weight:600;
+  padding:1px 7px;border-radius:10px;margin-left:4px}
+.impact-high{background:color-mix(in srgb,var(--critical) 12%,transparent);color:var(--critical)}
+.impact-medium{background:color-mix(in srgb,var(--warning) 12%,transparent);color:var(--warning)}
+.impact-low{background:color-mix(in srgb,var(--pass) 12%,transparent);color:var(--pass)}
+.effort-low{background:color-mix(in srgb,var(--pass) 12%,transparent);color:var(--pass)}
+.effort-medium{background:color-mix(in srgb,var(--info) 12%,transparent);color:var(--info)}
+.effort-high{background:color-mix(in srgb,var(--warning) 12%,transparent);color:var(--warning)}
+
+/* Score rationale table */
+table{width:100%;border-collapse:collapse;font-size:0.875rem}
+th,td{padding:8px 12px;text-align:left;border-bottom:1px solid var(--border)}
+th{background:var(--surface);font-weight:600;color:var(--muted);font-size:0.8rem;text-transform:uppercase;letter-spacing:0.04em}
+tr:last-child td{border-bottom:none;font-weight:700}
+
+/* Section headings */
+h2{font-size:1rem;font-weight:700;color:var(--muted);text-transform:uppercase;
+  letter-spacing:0.06em;margin:24px 0 12px}
+
+/* Footer */
+.report-footer{margin-top:32px;padding-top:16px;border-top:1px solid var(--border);
+  font-size:0.78rem;color:var(--muted2);display:flex;gap:16px;flex-wrap:wrap}
+`;
+
+// ── Severity JSON replacer (same as serializeJson) ────────────────────────────
+
+function severityReplacer(_key: string, value: unknown): unknown {
+  if (_key === 'severity' && typeof value === 'number') {
+    return SEVERITY_LABELS[value] ?? String(value);
+  }
+  return value;
+}
+
+// ── Main renderer ─────────────────────────────────────────────────────────────
+
+export function renderHtml(report: ScanReport, options?: HtmlReportOptions): string {
+  const pageTitle = options?.title ?? `quaid-scanner: ${report.repo}`;
+
+  const allWarnings = findingsBySeverity(report.findings, Severity.WARNING);
+  const realWarnings = allWarnings.filter((f) => !isErrorFinding(f));
+  const scannerErrorFindings = allWarnings.filter(isErrorFinding);
+  const criticals = findingsBySeverity(report.findings, Severity.CRITICAL).filter((f) => !isErrorFinding(f));
+  const infos = findingsBySeverity(report.findings, Severity.INFO).filter((f) => !isErrorFinding(f));
+
+  const repoDisplay = report.repo.split('/').pop() ?? report.repo;
+  const branchStr = report.metadata.branch ? ` · ${report.metadata.branch}` : '';
+  const durStr = (report.durationMs / 1000).toFixed(1);
+
+  // ── Header ───────────────────────────────────────────────────────────────
+  const header = `
+  <div class="report-header">
+    <div class="header-left">
+      <div class="repo-name">${esc(repoDisplay)}</div>
+      <div class="repo-meta">${esc(report.repo)}${branchStr}</div>
+      <div class="repo-meta">Maturity: ${esc(report.maturity)} · Depth: ${esc(report.depth)} · ${durStr}s</div>
+      <div class="repo-meta">Scanned: ${esc(report.scannedAt)}</div>
+      <div><span class="risk-badge risk-${esc(report.riskLevel)}">${esc(report.riskLevel)} RISK</span></div>
+    </div>
+    ${scoreRing(report.overallScore, report.riskLevel)}
+  </div>`;
+
+  // ── Pillar grid ───────────────────────────────────────────────────────────
+  const pillars = Object.values(Pillar).map((p) => pillarCard(p, report)).join('');
+  const pillarGrid = `<div class="pillar-grid">${pillars}</div>`;
+
+  // ── Findings sections ─────────────────────────────────────────────────────
+  let findingSections = '';
+
+  if (criticals.length > 0) {
+    const cards = criticals.map(criticalCard).join('');
+    findingSections += `
+    <details class="section" open>
+      <summary>🔴 Critical Findings <span class="section-count">${criticals.length}</span></summary>
+      <div class="section-body">${cards}</div>
+    </details>`;
+  }
+
+  if (realWarnings.length > 0) {
+    let rows: string;
+    if (options?.grouped) {
+      rows = groupFindings(realWarnings)
+        .map((g) => groupedFindingRow(g, Severity.WARNING))
+        .join('');
+    } else {
+      rows = realWarnings.map((f) => `
+        <div class="finding-row warning-row">
+          <span class="finding-id-small">${esc(f.id)}</span>
+          ${tierBadge(f)}
+          <span class="finding-msg">${esc(f.message)}</span>
+          <span class="finding-sugg">${esc(f.suggestion)}</span>
+          ${f.file ? `<code class="file-chip">${esc(f.file)}${f.line ? `:${f.line}` : ''}</code>` : ''}
+        </div>`).join('');
+    }
+    findingSections += `
+    <details class="section" open>
+      <summary>⚠️ Warnings <span class="section-count">${realWarnings.length} findings</span></summary>
+      <div class="section-body">${rows}</div>
+    </details>`;
+  }
+
+  const showScannerErrors = report.partial || scannerErrorFindings.length > 0;
+  if (showScannerErrors) {
+    const items = (report.failedScanners?.length
+      ? report.failedScanners.map((fs) => `<div><strong>${esc(fs.name)}</strong> — ${esc(fs.message)} (${esc(fs.reason)})</div>`)
+      : scannerErrorFindings.map((f) => `<div>${esc(f.message)}</div>`)
+    ).join('');
+    findingSections += `
+    <details class="section" open>
+      <summary>⚡ Scanner Errors</summary>
+      <div class="section-body">
+        <div class="callout callout-amber">
+          One or more scanners did not complete. Findings reflect scanner reliability issues, not repo health.
+          ${items}
+        </div>
+      </div>
+    </details>`;
+  }
+
+  if (infos.length > 0) {
+    let rows: string;
+    if (options?.grouped) {
+      rows = groupFindings(infos)
+        .map((g) => groupedFindingRow(g, Severity.INFO))
+        .join('');
+    } else {
+      rows = infos.map((f) => `
+        <div class="finding-row info-row">
+          <span class="finding-id-small">${esc(f.id)}</span>
+          ${tierBadge(f)}
+          <span class="finding-msg">${esc(f.message)}</span>
+          ${f.file ? `<code class="file-chip">${esc(f.file)}${f.line ? `:${f.line}` : ''}</code>` : ''}
+        </div>`).join('');
+    }
+    findingSections += `
+    <details class="section">
+      <summary>ℹ️ Info <span class="section-count">${infos.length} findings</span></summary>
+      <div class="section-body">${rows}</div>
+    </details>`;
+  }
+
+  if (report.findings.length === 0) {
+    findingSections = `<div class="callout callout-amber">✅ No findings — all checks passed.</div>`;
+  }
+
+  // ── Recommendations ───────────────────────────────────────────────────────
+  let recsHtml = '';
+  if (report.recommendations.length > 0) {
+    const items = report.recommendations.map((rec, i) => `
+      <li class="rec-item">
+        <span class="rec-priority">${i + 1}.</span>
+        <div class="rec-action">
+          ${esc(rec.action)}
+          <span class="impact-badge impact-${rec.impact}">${rec.impact} impact</span>
+          <span class="effort-badge effort-${rec.effort}">${rec.effort} effort</span>
+          ${rec.resources?.length ? `<div style="margin-top:4px;font-size:0.78rem;color:var(--muted)">${rec.resources.map((r) => `<a href="${esc(r)}">${esc(r)}</a>`).join(' ')}</div>` : ''}
+        </div>
+      </li>`).join('');
+    recsHtml = `<h2>Recommendations</h2><ul class="rec-list">${items}</ul>`;
+  }
+
+  // ── Score rationale ───────────────────────────────────────────────────────
+  const ratRows = (Object.keys(PILLAR_WEIGHTS) as Pillar[]).map((p) => {
+    const ps = report.pillars[p];
+    return `<tr>
+      <td>${PILLAR_LABELS[p]}</td>
+      <td>${(ps.weight * 100).toFixed(0)}%</td>
+      <td>${ps.score.toFixed(1)}</td>
+      <td>${ps.weightedScore.toFixed(2)}</td>
+    </tr>`;
+  }).join('');
+  const rationaleHtml = `
+    <h2>Score Rationale</h2>
+    <table>
+      <thead><tr><th>Pillar</th><th>Weight</th><th>Score</th><th>Contribution</th></tr></thead>
+      <tbody>${ratRows}</tbody>
+      <tfoot><tr><td><strong>Overall</strong></td><td>100%</td><td></td><td><strong>${report.overallScore.toFixed(2)}</strong></td></tr></tfoot>
+    </table>`;
+
+  // ── JSON embed ────────────────────────────────────────────────────────────
+  const jsonEmbed = `<script id="scan-data" type="application/json">${JSON.stringify(report, severityReplacer, 2)}</script>`;
+
+  // ── Footer ────────────────────────────────────────────────────────────────
+  const footer = `
+  <div class="report-footer">
+    <span>quaid-scanner v${esc(report.version)}</span>
+    <span>${esc(report.scannedAt)}</span>
+    ${report.metadata.commitSha ? `<span>Commit: <code>${esc(String(report.metadata.commitSha))}</code></span>` : ''}
+  </div>`;
+
+  // ── Assemble ──────────────────────────────────────────────────────────────
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${esc(pageTitle)}</title>
+<style>${INLINE_CSS}</style>
+</head>
+<body>
+${header}
+${pillarGrid}
+${findingSections}
+${recsHtml}
+${rationaleHtml}
+${footer}
+${jsonEmbed}
+</body>
+</html>`;
+}

--- a/src/reporters/markdown.ts
+++ b/src/reporters/markdown.ts
@@ -1,6 +1,8 @@
 import { Severity, Pillar, RiskLevel, PILLAR_WEIGHTS } from '../types/index.js';
 import type { ScanReport, Finding, FindingDataSource } from '../types/index.js';
 import { isErrorFinding } from '../issues.js';
+import { groupFindings, MAX_GROUP_REFS } from './utils.js';
+import type { FindingGroup } from './utils.js';
 
 const PILLAR_LABELS: Record<Pillar, string> = {
   [Pillar.SECURITY]: 'Security',
@@ -107,62 +109,6 @@ export interface MarkdownReportOptions {
   grouped?: boolean;
 }
 
-interface FindingGroup {
-  key: string;
-  representative: Finding;
-  members: Finding[];
-}
-
-/**
- * Normalise a finding message into a canonical group key by stripping
- * occurrence-specific details (context suffix, package version, etc.).
- */
-function canonicalKey(f: Finding): string {
-  const msg = f.message;
-
-  // "Non-inclusive term "X" found in <context>" → "Non-inclusive term "X""
-  const iniMatch = msg.match(/^(Non-inclusive term "[^"]+"|Found diminishing language "[^"]+")/);
-  if (iniMatch) return iniMatch[1];
-
-  // "Loosely pinned dependency "pkg": "^x.y.z" uses ^ prefix in devDependencies/..." → canonical
-  if (/Loosely pinned dependency .* uses \^ prefix in devDependencies/.test(msg)) {
-    return 'Loosely pinned devDependencies (^ prefix)';
-  }
-  if (/Loosely pinned dependency .* uses \^ prefix in/.test(msg)) {
-    return 'Loosely pinned dependency (^ prefix)';
-  }
-  if (/Loosely pinned dependency .* uses ~ prefix in devDependencies/.test(msg)) {
-    return 'Loosely pinned devDependencies (~ prefix)';
-  }
-
-  // "Undefined acronym "X" may confuse newcomers" → "Undefined acronym "X""
-  const acronymMatch = msg.match(/^(Undefined acronym "[^"]+")/);
-  if (acronymMatch) return acronymMatch[1];
-
-  // "Assumed knowledge: "X" command used without ..." → "Assumed knowledge: "X" command"
-  const akMatch = msg.match(/^(Assumed knowledge: "[^"]+" (?:command|operation))/);
-  if (akMatch) return akMatch[1];
-
-  // Fallback: use the full message as key (no grouping unless identical)
-  return msg;
-}
-
-function groupFindings(findings: Finding[]): FindingGroup[] {
-  const map = new Map<string, FindingGroup>();
-
-  for (const f of findings) {
-    const key = canonicalKey(f);
-    const existing = map.get(key);
-    if (existing) {
-      existing.members.push(f);
-    } else {
-      map.set(key, { key, representative: f, members: [f] });
-    }
-  }
-
-  return [...map.values()];
-}
-
 /** Render a grouped finding entry for Warnings/Info sections. */
 function renderGroupedFinding(group: FindingGroup): string[] {
   const { key, representative: rep, members } = group;
@@ -185,14 +131,13 @@ function renderGroupedFinding(group: FindingGroup): string[] {
   if (extras.length > 0) lines.push(`  ${extras.join(' ')}`);
 
   // File:line refs — show first 5, then "+N more"
-  const MAX_REFS = 5;
   const withFile = members.filter((m) => m.file);
-  const refs = withFile.slice(0, MAX_REFS).map((m) => {
+  const refs = withFile.slice(0, MAX_GROUP_REFS).map((m) => {
     const loc = m.line ? `${m.file}:${m.line}` : m.file!;
     const ctx = m.context ? ` (${m.context})` : '';
     return `\`${loc}\`${ctx}`;
   });
-  if (withFile.length > MAX_REFS) refs.push(`_+${withFile.length - MAX_REFS} more_`);
+  if (withFile.length > MAX_GROUP_REFS) refs.push(`_+${withFile.length - MAX_GROUP_REFS} more_`);
   if (refs.length > 0) lines.push(`  ${refs.join(' · ')}`);
 
   return lines;

--- a/src/reporters/utils.ts
+++ b/src/reporters/utils.ts
@@ -1,0 +1,60 @@
+import type { Finding } from '../types/index.js';
+
+export interface FindingGroup {
+  key: string;
+  representative: Finding;
+  members: Finding[];
+}
+
+/**
+ * Normalise a finding message into a canonical group key by stripping
+ * occurrence-specific details (context suffix, package version, etc.).
+ * Used by both markdown and HTML renderers for consistent grouping.
+ */
+export function canonicalKey(f: Finding): string {
+  const msg = f.message;
+
+  // "Non-inclusive term "X" found in <context>" → "Non-inclusive term "X""
+  const iniMatch = msg.match(/^(Non-inclusive term "[^"]+"|Found diminishing language "[^"]+")/);
+  if (iniMatch) return iniMatch[1];
+
+  // Loosely pinned devDependencies
+  if (/Loosely pinned dependency .* uses \^ prefix in devDependencies/.test(msg)) {
+    return 'Loosely pinned devDependencies (^ prefix)';
+  }
+  if (/Loosely pinned dependency .* uses \^ prefix in/.test(msg)) {
+    return 'Loosely pinned dependency (^ prefix)';
+  }
+  if (/Loosely pinned dependency .* uses ~ prefix in devDependencies/.test(msg)) {
+    return 'Loosely pinned devDependencies (~ prefix)';
+  }
+
+  // "Undefined acronym "X" may confuse newcomers" → "Undefined acronym "X""
+  const acronymMatch = msg.match(/^(Undefined acronym "[^"]+")/);
+  if (acronymMatch) return acronymMatch[1];
+
+  // "Assumed knowledge: "X" command used without ..." → "Assumed knowledge: "X" command"
+  const akMatch = msg.match(/^(Assumed knowledge: "[^"]+" (?:command|operation))/);
+  if (akMatch) return akMatch[1];
+
+  return msg;
+}
+
+export function groupFindings(findings: Finding[]): FindingGroup[] {
+  const map = new Map<string, FindingGroup>();
+
+  for (const f of findings) {
+    const key = canonicalKey(f);
+    const existing = map.get(key);
+    if (existing) {
+      existing.members.push(f);
+    } else {
+      map.set(key, { key, representative: f, members: [f] });
+    }
+  }
+
+  return [...map.values()];
+}
+
+/** Maximum file:line refs to show before "+ more" truncation. */
+export const MAX_GROUP_REFS = 5;

--- a/tests/reporters/html.test.ts
+++ b/tests/reporters/html.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from 'vitest';
+import { renderHtml } from '../../src/reporters/html.js';
+import { buildScanReport } from '../../src/reporters/json.js';
+import { DEFAULT_CONFIG } from '../../src/config.js';
+import {
+  Pillar,
+  Severity,
+  RiskLevel,
+  MaturityLevel,
+  PILLAR_WEIGHTS,
+} from '../../src/types/index.js';
+import type { ScanReport, Finding } from '../../src/types/index.js';
+import type { OrchestratorResult } from '../../src/scanner/orchestrator.js';
+
+function makePillars() {
+  return Object.fromEntries(
+    Object.values(Pillar).map((p) => [
+      p,
+      {
+        score: 7.5,
+        weight: PILLAR_WEIGHTS[p],
+        weightedScore: 7.5 * PILLAR_WEIGHTS[p],
+        counts: { critical: 0, warning: 1, info: 0, pass: 2 },
+        scanners: ['scanner-a'],
+      },
+    ]),
+  ) as OrchestratorResult['pillars'];
+}
+
+function makeReport(findingsOverride?: Finding[]): ScanReport {
+  const result: OrchestratorResult = {
+    overallScore: 7.5,
+    riskLevel: RiskLevel.MEDIUM,
+    pillars: makePillars(),
+    findings: findingsOverride ?? [
+      {
+        id: 'gov-01',
+        severity: Severity.WARNING,
+        pillar: Pillar.GOVERNANCE,
+        category: 'license',
+        message: 'No license file found',
+        file: null,
+        line: null,
+        column: null,
+        suggestion: 'Add a LICENSE file',
+      },
+    ],
+    thresholdPassed: true,
+    durationMs: 2000,
+  };
+
+  return buildScanReport(
+    { type: 'local' as const, value: '/tmp/my-repo' },
+    result,
+    DEFAULT_CONFIG,
+    MaturityLevel.INCUBATING,
+    '1.0.0',
+  );
+}
+
+function makeAbortFindings(count: number): Finding[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `INC-NAMING-abort-src/client.ts:${i + 1}`,
+    severity: Severity.WARNING,
+    pillar: Pillar.INCLUSIVE,
+    category: 'non-inclusive-term',
+    message: `Non-inclusive term "abort" found in string literal`,
+    file: `src/client.ts`,
+    line: i + 1,
+    column: 1,
+    suggestion: 'Replace with: cancel, terminate, stop, halt',
+    referenceUrl: 'https://inclusivenaming.org/word-lists/tier-1/abort/',
+    dataSource: 'local' as const,
+    metadata: { tier: 1 as const },
+  }));
+}
+
+describe('renderHtml', () => {
+  describe('basic structure', () => {
+    it('returns a string starting with <!DOCTYPE html>', () => {
+      const html = renderHtml(makeReport());
+      expect(html.trimStart()).toMatch(/^<!DOCTYPE html>/i);
+    });
+
+    it('contains the repo name', () => {
+      const html = renderHtml(makeReport());
+      expect(html).toContain('my-repo');
+    });
+
+    it('contains the overall score', () => {
+      const html = renderHtml(makeReport());
+      expect(html).toContain('7.5');
+    });
+
+    it('contains all six pillar names', () => {
+      const html = renderHtml(makeReport());
+      expect(html).toContain('Security');
+      expect(html).toContain('Governance');
+      expect(html).toContain('Community');
+      expect(html).toContain('AI Readiness');
+      expect(html).toContain('Inclusive');
+      expect(html).toContain('Technical');
+    });
+
+    it('is a non-empty string', () => {
+      const html = renderHtml(makeReport());
+      expect(typeof html).toBe('string');
+      expect(html.length).toBeGreaterThan(500);
+    });
+  });
+
+  describe('self-contained (no external URLs)', () => {
+    it('has no external <link> tags', () => {
+      const html = renderHtml(makeReport());
+      expect(html).not.toMatch(/<link[^>]+href=["']https?:/i);
+    });
+
+    it('has no external <script src> tags', () => {
+      const html = renderHtml(makeReport());
+      expect(html).not.toMatch(/<script[^>]+src=["']https?:/i);
+    });
+  });
+
+  describe('dark mode', () => {
+    it('includes prefers-color-scheme: dark in inline CSS', () => {
+      const html = renderHtml(makeReport());
+      expect(html).toContain('prefers-color-scheme');
+      expect(html).toContain('dark');
+    });
+  });
+
+  describe('JSON embed', () => {
+    it('embeds JSON in a <script id="scan-data"> tag', () => {
+      const html = renderHtml(makeReport());
+      expect(html).toContain('id="scan-data"');
+      expect(html).toContain('type="application/json"');
+    });
+
+    it('embedded JSON is valid and parseable', () => {
+      const html = renderHtml(makeReport());
+      const match = html.match(/<script[^>]+id="scan-data"[^>]*>([\s\S]*?)<\/script>/);
+      expect(match).not.toBeNull();
+      expect(() => JSON.parse(match![1])).not.toThrow();
+    });
+
+    it('embedded JSON contains the repo name', () => {
+      const html = renderHtml(makeReport());
+      const match = html.match(/<script[^>]+id="scan-data"[^>]*>([\s\S]*?)<\/script>/);
+      const data = JSON.parse(match![1]);
+      expect(data.repo).toContain('my-repo');
+    });
+  });
+
+  describe('critical findings', () => {
+    it('renders critical findings individually (not grouped)', () => {
+      const criticals: Finding[] = Array.from({ length: 3 }, (_, i) => ({
+        id: `SEC-CRIT-${i}`,
+        severity: Severity.CRITICAL,
+        pillar: Pillar.SECURITY,
+        category: 'secret-exposure',
+        message: 'Hardcoded secret detected',
+        file: `src/file${i}.ts`,
+        line: 1,
+        column: 1,
+        suggestion: 'Remove and rotate this secret',
+      }));
+      const html = renderHtml(makeReport(criticals), { grouped: true });
+
+      expect(html).toContain('SEC-CRIT-0');
+      expect(html).toContain('SEC-CRIT-1');
+      expect(html).toContain('SEC-CRIT-2');
+    });
+  });
+
+  describe('grouped rendering', () => {
+    it('collapses repeat-message warnings when grouped: true', () => {
+      const findings = makeAbortFindings(11);
+      const html = renderHtml(makeReport(findings), { grouped: true });
+
+      const abortMatches = [...html.matchAll(/Non-inclusive term &quot;abort&quot;|Non-inclusive term "abort"/g)];
+      expect(abortMatches.length).toBeLessThanOrEqual(2); // at most one in the display, one in the JSON embed
+      expect(html).toContain('11 occurrences');
+    });
+
+    it('shows "+N more" for groups larger than 5', () => {
+      const findings = makeAbortFindings(11);
+      const html = renderHtml(makeReport(findings), { grouped: true });
+      expect(html).toContain('+6 more');
+    });
+
+    it('renders each finding separately when grouped: false', () => {
+      const findings = makeAbortFindings(3);
+      const html = renderHtml(makeReport(findings), { grouped: false });
+
+      expect(html).toContain('INC-NAMING-abort-src/client.ts:1');
+      expect(html).toContain('INC-NAMING-abort-src/client.ts:2');
+      expect(html).toContain('INC-NAMING-abort-src/client.ts:3');
+    });
+  });
+
+  describe('score ring', () => {
+    it('contains an SVG element', () => {
+      const html = renderHtml(makeReport());
+      expect(html).toContain('<svg');
+      expect(html).toContain('</svg>');
+    });
+
+    it('contains a circle element for the score ring', () => {
+      const html = renderHtml(makeReport());
+      expect(html).toContain('<circle');
+    });
+  });
+});

--- a/tests/reporters/html.test.ts
+++ b/tests/reporters/html.test.ts
@@ -210,4 +210,252 @@ describe('renderHtml', () => {
       expect(html).toContain('<circle');
     });
   });
+
+  describe('critical finding card optional fields', () => {
+    it('renders file and line when present', () => {
+      const f: Finding = {
+        id: 'SEC-01', severity: Severity.CRITICAL, pillar: Pillar.SECURITY,
+        category: 'secret', message: 'Secret found', file: 'src/auth.ts', line: 42,
+        column: 1, suggestion: 'Remove it', referenceUrl: 'https://example.com',
+        context: 'const API_KEY = "abc123"',
+      };
+      const html = renderHtml(makeReport([f]));
+      expect(html).toContain('src/auth.ts');
+      expect(html).toContain(':42');
+      expect(html).toContain('example.com');
+      expect(html).toContain('abc123');
+    });
+
+    it('renders without optional fields when absent', () => {
+      const f: Finding = {
+        id: 'SEC-02', severity: Severity.CRITICAL, pillar: Pillar.SECURITY,
+        category: 'secret', message: 'Secret found', file: null, line: null,
+        column: null, suggestion: 'Remove it',
+      };
+      const html = renderHtml(makeReport([f]));
+      expect(html).toContain('SEC-02');
+      expect(html).toContain('Remove it');
+    });
+  });
+
+  describe('tier badge', () => {
+    it('renders tier badge for tier-1 findings', () => {
+      const f: Finding = {
+        id: 'INC-01', severity: Severity.CRITICAL, pillar: Pillar.INCLUSIVE,
+        category: 'non-inclusive-term', message: 'Non-inclusive term "abort" found',
+        file: null, line: null, column: null,
+        suggestion: 'Replace with: cancel',
+        metadata: { tier: 1 as const },
+      };
+      const html = renderHtml(makeReport([f]));
+      expect(html).toContain('tier-badge');
+      expect(html).toContain('Tier 1');
+    });
+
+    it('renders tier-2 and tier-3 badge labels', () => {
+      const f2: Finding = {
+        id: 'INC-02', severity: Severity.WARNING, pillar: Pillar.INCLUSIVE,
+        category: 'term', message: 'term found', file: null, line: null, column: null,
+        suggestion: 'Replace', metadata: { tier: 2 as const },
+      };
+      const f3: Finding = {
+        id: 'INC-03', severity: Severity.WARNING, pillar: Pillar.INCLUSIVE,
+        category: 'term', message: 'term found 2', file: null, line: null, column: null,
+        suggestion: 'Replace', metadata: { tier: 3 as const },
+      };
+      const html2 = renderHtml(makeReport([f2]));
+      const html3 = renderHtml(makeReport([f3]));
+      expect(html2).toContain('Tier 2');
+      expect(html3).toContain('Tier 3');
+    });
+  });
+
+  describe('pillar card score colors', () => {
+    function makePillarsWithScore(score: number) {
+      return Object.fromEntries(
+        Object.values(Pillar).map((p) => [
+          p,
+          {
+            score,
+            weight: PILLAR_WEIGHTS[p],
+            weightedScore: score * PILLAR_WEIGHTS[p],
+            counts: { critical: 1, warning: 1, info: 1, pass: 0 },
+            scanners: ['scanner-a'],
+          },
+        ]),
+      ) as OrchestratorResult['pillars'];
+    }
+
+    it('shows critical color (var(--critical)) for score < 4', () => {
+      const result: OrchestratorResult = {
+        overallScore: 3.0, riskLevel: RiskLevel.CRITICAL,
+        pillars: makePillarsWithScore(3.0),
+        findings: [], thresholdPassed: false, durationMs: 1000,
+      };
+      const report = buildScanReport(
+        { type: 'local' as const, value: '/tmp/low-score-repo' },
+        result, DEFAULT_CONFIG, MaturityLevel.INCUBATING, '1.0.0',
+      );
+      const html = renderHtml(report);
+      expect(html).toContain('var(--critical)');
+    });
+
+    it('shows warning color (var(--warning)) for score between 4 and 7', () => {
+      const result: OrchestratorResult = {
+        overallScore: 5.0, riskLevel: RiskLevel.HIGH,
+        pillars: makePillarsWithScore(5.0),
+        findings: [], thresholdPassed: true, durationMs: 1000,
+      };
+      const report = buildScanReport(
+        { type: 'local' as const, value: '/tmp/mid-score-repo' },
+        result, DEFAULT_CONFIG, MaturityLevel.INCUBATING, '1.0.0',
+      );
+      const html = renderHtml(report);
+      expect(html).toContain('var(--warning)');
+    });
+  });
+
+  describe('info section', () => {
+    it('renders info findings ungrouped by default', () => {
+      const infos: Finding[] = [
+        { id: 'AI-01', severity: Severity.INFO, pillar: Pillar.AI_READINESS,
+          category: 'model-card', message: 'No model card found', file: null,
+          line: null, column: null, suggestion: 'Add MODEL_CARD.md' },
+        { id: 'AI-02', severity: Severity.INFO, pillar: Pillar.AI_READINESS,
+          category: 'model-card', message: 'No dataset provenance', file: 'README.md',
+          line: 1, column: 1, suggestion: 'Document sources' },
+      ];
+      const html = renderHtml(makeReport(infos));
+      expect(html).toContain('AI-01');
+      expect(html).toContain('AI-02');
+      expect(html).toContain('README.md');
+    });
+
+    it('renders info findings grouped when grouped: true', () => {
+      const infos: Finding[] = Array.from({ length: 3 }, (_, i) => ({
+        id: `AI-0${i}`, severity: Severity.INFO, pillar: Pillar.AI_READINESS,
+        category: 'model-card', message: 'No model card found',
+        file: `src/model${i}.ts`, line: 1, column: 1, suggestion: 'Add MODEL_CARD.md',
+      }));
+      const html = renderHtml(makeReport(infos), { grouped: true });
+      expect(html).toContain('occurrences');
+    });
+  });
+
+  describe('scanner errors section', () => {
+    it('shows scanner errors callout when report.partial is true', () => {
+      const report = makeReport();
+      const partialReport = {
+        ...report,
+        partial: true,
+        failedScanners: [{ name: 'openssf', reason: 'timeout', message: 'API timed out', pillar: 'security' }],
+      } as ScanReport;
+      const html = renderHtml(partialReport);
+      expect(html).toContain('Scanner Errors');
+      expect(html).toContain('openssf');
+    });
+
+    it('shows scanner error findings when no failedScanners list', () => {
+      const errorFinding: Finding = {
+        id: 'SCANNER-FAIL-openssf', severity: Severity.WARNING,
+        pillar: Pillar.SECURITY, category: 'timeout',
+        message: 'OpenSSF scorecard scanner failed', file: null,
+        line: null, column: null, suggestion: 'Retry later',
+      };
+      const report = makeReport([errorFinding]);
+      const html = renderHtml(report);
+      expect(html).toContain('Scanner Errors');
+    });
+  });
+
+  describe('empty findings', () => {
+    it('shows no-findings callout when findings array is empty', () => {
+      const result: OrchestratorResult = {
+        overallScore: 9.5, riskLevel: RiskLevel.LOW,
+        pillars: Object.fromEntries(
+          Object.values(Pillar).map((p) => [p, {
+            score: 9.5, weight: PILLAR_WEIGHTS[p], weightedScore: 9.5 * PILLAR_WEIGHTS[p],
+            counts: { critical: 0, warning: 0, info: 0, pass: 5 }, scanners: ['scanner-a'],
+          }]),
+        ) as OrchestratorResult['pillars'],
+        findings: [], thresholdPassed: true, durationMs: 500,
+      };
+      const report = buildScanReport(
+        { type: 'local' as const, value: '/tmp/clean-repo' },
+        result, DEFAULT_CONFIG, MaturityLevel.GRADUATED, '1.0.0',
+      );
+      const html = renderHtml(report);
+      expect(html).toContain('No findings');
+    });
+  });
+
+  describe('recommendations section', () => {
+    it('renders recommendations when present', () => {
+      const report = makeReport();
+      const withRecs: ScanReport = {
+        ...report,
+        recommendations: [
+          { action: 'Add a SECURITY.md', impact: 'high', effort: 'low', resources: ['https://example.com/security'] },
+          { action: 'Add CI badge', impact: 'medium', effort: 'medium' },
+        ],
+      };
+      const html = renderHtml(withRecs);
+      expect(html).toContain('Recommendations');
+      expect(html).toContain('Add a SECURITY.md');
+      expect(html).toContain('example.com/security');
+      expect(html).toContain('high impact');
+    });
+  });
+
+  describe('metadata fields', () => {
+    it('includes branch in header when metadata.branch is set', () => {
+      const report = makeReport();
+      const withBranch: ScanReport = {
+        ...report,
+        metadata: { ...report.metadata, branch: 'feat/html-reporter' },
+      };
+      const html = renderHtml(withBranch);
+      expect(html).toContain('feat/html-reporter');
+    });
+
+    it('includes commitSha in footer when set', () => {
+      const report = makeReport();
+      const withSha: ScanReport = {
+        ...report,
+        metadata: { ...report.metadata, commitSha: 'abc1234' },
+      };
+      const html = renderHtml(withSha);
+      expect(html).toContain('abc1234');
+    });
+
+    it('uses custom title when options.title is set', () => {
+      const html = renderHtml(makeReport(), { title: 'My Custom Title' });
+      expect(html).toContain('<title>My Custom Title</title>');
+    });
+  });
+
+  describe('single-occurrence grouped row', () => {
+    it('renders single occurrence without grouping header', () => {
+      const single: Finding = {
+        id: 'INC-NAMING-abort-src/one.ts:1',
+        severity: Severity.WARNING, pillar: Pillar.INCLUSIVE,
+        category: 'non-inclusive-term', message: 'Non-inclusive term "abort" found',
+        file: 'src/one.ts', line: 1, column: 1,
+        suggestion: 'Replace with: cancel',
+      };
+      const html = renderHtml(makeReport([single]), { grouped: true });
+      expect(html).toContain('src/one.ts');
+      expect(html).not.toContain('occurrences');
+    });
+
+    it('renders single occurrence without file chip when file is null', () => {
+      const single: Finding = {
+        id: 'GOV-01', severity: Severity.WARNING, pillar: Pillar.GOVERNANCE,
+        category: 'license', message: 'No license found', file: null,
+        line: null, column: null, suggestion: 'Add LICENSE',
+      };
+      const html = renderHtml(makeReport([single]), { grouped: true });
+      expect(html).toContain('GOV-01');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Extracts `groupFindings()` / `canonicalKey()` / `FindingGroup` from `markdown.ts` → new `src/reporters/utils.ts` (shared by both renderers)
- Implements `renderHtml(report, options?)` in `src/reporters/html.ts` — fully self-contained HTML with no external URLs
- Exports `renderHtml` and `HtmlReportOptions` from `src/index.ts`
- 34 tests in `tests/reporters/html.test.ts` covering structure, self-containment, dark mode, JSON embed, grouping, score ring, critical cards, tier badges, scanner errors, info section, empty findings, recommendations, metadata fields

## Acceptance Criteria

- [x] 8.8.1 `renderHtml()` exported from `src/index.ts`
- [x] 8.8.2 Output is fully self-contained (no external `<link>` or `<script src>`)
- [x] 8.8.3 JSON scan data embedded as `<script id="scan-data" type="application/json">`
- [x] 8.8.4 Score ring (SVG), 6-pillar card grid, severity-grouped findings sections rendered
- [x] 8.8.5 `grouped: true` collapses repeat-message findings identically to the markdown renderer
- [x] 8.8.6 `prefers-color-scheme: dark` alternate palette present in inline CSS
- [x] 8.8.7 `groupFindings()` and `canonicalKey()` extracted to `src/reporters/utils.ts` and imported by both renderers
- [x] 8.8.8 `npm run test:coverage` ≥ 80% statements and branches (97.64% / 92.48%)

## Commits

1. `refactor: extract groupFindings/canonicalKey to reporters/utils Refs #198`
2. `test: red — HTML reporter returns valid self-contained HTML Refs #198` (prior commit)
3. `feat: renderHtml() — self-contained HTML report renderer Closes #198`