### PR TITLE
fix: drop hardcoded 'Replace with:' prefix in grouped renderer (#203)

### DIFF
--- a/src/reporters/markdown.ts
+++ b/src/reporters/markdown.ts
@@ -126,7 +126,7 @@ function renderGroupedFinding(group: FindingGroup): string[] {
   lines.push(`- **[${rep.pillar}] ${key}** — ${members.length} occurrences${tierSuffix}`);
 
   const extras: string[] = [];
-  if (rep.suggestion) extras.push(`  Replace with: ${rep.suggestion}`);
+  if (rep.suggestion) extras.push(`  ${rep.suggestion}`);
   if (rep.referenceUrl) extras.push(`· [Reference](${rep.referenceUrl})`);
   if (extras.length > 0) lines.push(`  ${extras.join(' ')}`);
 

--- a/tests/reporters/markdown.test.ts
+++ b/tests/reporters/markdown.test.ts
@@ -1148,5 +1148,29 @@ describe('renderMarkdown', () => {
       expect(md).toContain('Replace with: cancel, terminate, stop, halt');
       expect(md).toContain('https://inclusivenaming.org/word-lists/tier-1/abort/');
     });
+
+    // Regression: #203 — grouped renderer was hardcoding "Replace with: " in front
+    // of suggestions that already carried their own lead-in ("Consider using:",
+    // "Remove ...", "Consider removing ..."), producing doubled phrasing.
+    it('does not prepend "Replace with:" when the suggestion already carries a lead-in', () => {
+      const findings: Finding[] = Array.from({ length: 3 }, (_, i) => ({
+        id: `INC-NAMING-abort-src/client.ts:${i + 1}`,
+        severity: Severity.WARNING,
+        pillar: Pillar.INCLUSIVE,
+        category: 'non-inclusive-term',
+        message: `Non-inclusive term "abort" found in string literal`,
+        file: `src/client.ts`,
+        line: i + 1,
+        column: 1,
+        suggestion: 'Consider using: cancel, terminate, stop, halt',
+        dataSource: 'local' as const,
+      }));
+      const report = makeReport(findings);
+      const md = renderMarkdown(report, { grouped: true });
+
+      expect(md).not.toMatch(/Replace with: Consider/);
+      expect(md).not.toMatch(/Replace with: Remove/);
+      expect(md).toContain('Consider using: cancel, terminate, stop, halt');
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Grouped markdown renderer was hardcoding `Replace with: ` in front of every suggestion, producing doubled lead-ins ("Replace with: Consider using:", "Replace with: Remove ...", etc.) since suggestions already carry their own lead-in phrase.
- One-line fix in `src/reporters/markdown.ts`: render `rep.suggestion` verbatim, matching the single-finding code path.
- HTML renderer (`src/reporters/html.ts:197`) already does the right thing — no change needed there.

## Test plan

- [x] Regression test added in `tests/reporters/markdown.test.ts` — asserts grouped output does NOT contain `Replace with: Consider` or `Replace with: Remove`, and DOES contain the verbatim suggestion
- [x] Red commit (`a07d2fb`) confirmed test fails before the fix
- [x] `npm test` — all 1670 tests pass

Closes #203