### PR TITLE
fix: cap context length in grouped markdown renderer (#201)

### DIFF
--- a/src/reporters/markdown.ts
+++ b/src/reporters/markdown.ts
@@ -1,7 +1,7 @@
 import { Severity, Pillar, RiskLevel, PILLAR_WEIGHTS } from '../types/index.js';
 import type { ScanReport, Finding, FindingDataSource } from '../types/index.js';
 import { isErrorFinding } from '../issues.js';
-import { groupFindings, MAX_GROUP_REFS } from './utils.js';
+import { groupFindings, MAX_GROUP_REFS, truncateContext } from './utils.js';
 import type { FindingGroup } from './utils.js';
 
 const PILLAR_LABELS: Record<Pillar, string> = {
@@ -134,7 +134,8 @@ function renderGroupedFinding(group: FindingGroup): string[] {
   const withFile = members.filter((m) => m.file);
   const refs = withFile.slice(0, MAX_GROUP_REFS).map((m) => {
     const loc = m.line ? `${m.file}:${m.line}` : m.file!;
-    const ctx = m.context ? ` (${m.context})` : '';
+    const truncated = truncateContext(m.context);
+    const ctx = truncated ? ` (${truncated})` : '';
     return `\`${loc}\`${ctx}`;
   });
   if (withFile.length > MAX_GROUP_REFS) refs.push(`_+${withFile.length - MAX_GROUP_REFS} more_`);

--- a/src/reporters/utils.ts
+++ b/src/reporters/utils.ts
@@ -58,3 +58,24 @@ export function groupFindings(findings: Finding[]): FindingGroup[] {
 
 /** Maximum file:line refs to show before "+ more" truncation. */
 export const MAX_GROUP_REFS = 5;
+
+/**
+ * Truncate a `context` excerpt for safe display in reports.
+ * Collapses internal whitespace runs to single spaces by default — passing
+ * `collapseWhitespace: false` preserves newlines for block contexts.
+ * Appends '…' when the result is truncated. Returns '' for null/undefined.
+ *
+ * Why: minified single-line bundles can have matched lines tens of KB long,
+ * which dominate grouped reports with unreadable noise (#201).
+ */
+export function truncateContext(
+  s: string | null | undefined,
+  opts: { max?: number; collapseWhitespace?: boolean } = {},
+): string {
+  if (s == null) return '';
+  const max = opts.max ?? 120;
+  const collapse = opts.collapseWhitespace ?? true;
+  const normalized = (collapse ? s.replace(/\s+/g, ' ') : s).trim();
+  if (normalized.length <= max) return normalized;
+  return normalized.slice(0, max - 1) + '…';
+}

--- a/tests/reporters/markdown.test.ts
+++ b/tests/reporters/markdown.test.ts
@@ -1149,6 +1149,34 @@ describe('renderMarkdown', () => {
       expect(md).toContain('https://inclusivenaming.org/word-lists/tier-1/abort/');
     });
 
+    // Regression: #201 — grouped renderer was emitting raw `context` field with no
+    // length cap. A single matched line inside a minified bundle could be 89 KB,
+    // blowing up the report to hundreds of KB of unreadable noise.
+    it('caps very long context excerpts in grouped file refs (#201)', () => {
+      const minifiedLine = 'function abort(){throw new Error("aborted")}'.repeat(2000); // ~90 KB
+      const findings: Finding[] = Array.from({ length: 3 }, (_, i) => ({
+        id: `INC-NAMING-abort-html/assets/index-9agQl9q3.js:${i + 1}`,
+        severity: Severity.WARNING,
+        pillar: Pillar.INCLUSIVE,
+        category: 'non-inclusive-term',
+        message: `Non-inclusive term "abort" found in string literal`,
+        file: `html/assets/index-9agQl9q3.js`,
+        line: i + 1,
+        column: 1,
+        context: minifiedLine,
+        suggestion: 'Consider using: cancel, terminate, stop, halt',
+        dataSource: 'local' as const,
+      }));
+      const report = makeReport(findings);
+      const md = renderMarkdown(report, { grouped: true });
+
+      // No single line in the rendered output should be tens of KB long
+      const longestLine = md.split('\n').reduce((m, l) => Math.max(m, l.length), 0);
+      expect(longestLine).toBeLessThan(500);
+      // The context truncation marker should be present
+      expect(md).toContain('…');
+    });
+
     // Regression: #203 — grouped renderer was hardcoding "Replace with: " in front
     // of suggestions that already carried their own lead-in ("Consider using:",
     // "Remove ...", "Consider removing ..."), producing doubled phrasing.

--- a/tests/reporters/utils.test.ts
+++ b/tests/reporters/utils.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { truncateContext } from '../../src/reporters/utils.js';
+
+describe('truncateContext (#201)', () => {
+  it('returns empty string for null', () => {
+    expect(truncateContext(null)).toBe('');
+  });
+
+  it('returns empty string for undefined', () => {
+    expect(truncateContext(undefined)).toBe('');
+  });
+
+  it('returns input unchanged when shorter than max', () => {
+    expect(truncateContext('short snippet')).toBe('short snippet');
+  });
+
+  it('truncates with ellipsis when longer than default max (120)', () => {
+    const long = 'x'.repeat(200);
+    const out = truncateContext(long);
+    expect(out.length).toBe(120);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  it('respects custom max option', () => {
+    const long = 'x'.repeat(200);
+    const out = truncateContext(long, { max: 50 });
+    expect(out.length).toBe(50);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  it('collapses whitespace runs to single spaces by default', () => {
+    expect(truncateContext('foo   bar\n\nbaz\t\tqux')).toBe('foo bar baz qux');
+  });
+
+  it('trims leading and trailing whitespace', () => {
+    expect(truncateContext('  hello world  ')).toBe('hello world');
+  });
+
+  it('preserves newlines when collapseWhitespace=false', () => {
+    expect(truncateContext('line1\nline2', { collapseWhitespace: false })).toBe('line1\nline2');
+  });
+
+  it('caps a minified single-line bundle to 120 chars (the #201 case)', () => {
+    const minified = 'function abort(){throw new Error("aborted")}'.repeat(2000); // ~90 KB
+    const out = truncateContext(minified);
+    expect(out.length).toBe(120);
+    expect(out.endsWith('…')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Minified single-line files (Vite bundles, Webpack outputs, etc.) can produce matched lines tens of KB long. The grouped markdown renderer was emitting these verbatim, ballooning reports to 100+ KB of unreadable noise dominated by a single line of minified JS.

**Fix**: shared `truncateContext(s, opts)` helper in `src/reporters/utils.ts`. Collapses whitespace and caps to 120 chars by default (with ellipsis). Applied in `src/reporters/markdown.ts` grouped ref builder where `Finding.context` is emitted.

## Scope notes

- HTML's grouped path doesn't emit context (just file:line chips), so no change needed there.
- HTML critical card's `<pre>` block is intentionally left alone — critical findings benefit from full multi-line context and rarely land in minified bundles. Companion fix #202 will stop scanning minified bundles entirely, which is the root-cause fix.

## Test plan

- [x] New `tests/reporters/utils.test.ts` — 9 tests covering `truncateContext()`: null/undefined, short-input passthrough, default-120 cap, custom max, whitespace collapse, trim, `collapseWhitespace:false`, the actual 90KB minified case
- [x] Markdown integration test asserts longest rendered line is <500 chars when given a 90KB context, and that `…` appears
- [x] Red commit (`a31559d`) confirmed both tests fail before fix
- [x] Full suite: 1680/1680 passing

Closes #201