### PR TITLE
fix: exclude self-generated .html reports from inclusive scanners (#207)

### DIFF
--- a/src/scanner/inclusive/diminishing-scanner.ts
+++ b/src/scanner/inclusive/diminishing-scanner.ts
@@ -15,6 +15,7 @@ import type { Scanner, ScanContext, Finding } from '../../types/index.js';
 import { Pillar, Severity } from '../../types/index.js';
 import { loadIgnorePatterns } from './ignore-file.js';
 import { isMinifiedContent } from './utils/is-minified.js';
+import { SELF_REPORT_GLOBS } from './utils/self-report-globs.js';
 
 /** A diminishing language pattern definition. */
 interface DiminishingPattern {
@@ -312,7 +313,7 @@ export class DiminishingLanguageScanner implements Scanner {
         cwd: repoPath,
         absolute: true,
         nodir: true,
-        ignore: ['**/node_modules/**', '**/dist/**', '**/build/**', '**/out/**', '**/.next/**', '**/.nuxt/**', '**/coverage/**', '**/.git/**', '**/quaid-scan-*.md', '**/quaid-scan-*.json', ...userIgnore],
+        ignore: ['**/node_modules/**', '**/dist/**', '**/build/**', '**/out/**', '**/.next/**', '**/.nuxt/**', '**/coverage/**', '**/.git/**', ...SELF_REPORT_GLOBS, ...userIgnore],
       });
       for (const f of matched) {
         fileSet.add(f);

--- a/src/scanner/inclusive/doc-scanner.ts
+++ b/src/scanner/inclusive/doc-scanner.ts
@@ -15,6 +15,7 @@ import { TermListManager, type LoadedTerm } from './term-list.js';
 import { loadIgnorePatterns } from './ignore-file.js';
 import { resolveInclusiveConfig } from './resolve-config.js';
 import { isMinifiedContent } from './utils/is-minified.js';
+import { SELF_REPORT_GLOBS } from './utils/self-report-globs.js';
 
 /** File extensions considered documentation files. */
 const DOC_EXTENSIONS = ['md', 'txt', 'rst', 'adoc', 'html'];
@@ -133,8 +134,7 @@ export class InclusiveDocScanner implements Scanner {
     const patterns = DOC_EXTENSIONS.map((ext) => `**/*.${ext}`);
     const ignorePatterns = [
       ...EXCLUDED_DIRS.map((dir) => `${dir}/**`),
-      '**/quaid-scan-*.md',
-      '**/quaid-scan-*.json',
+      ...SELF_REPORT_GLOBS,
       ...userExcludes,
     ];
 

--- a/src/scanner/inclusive/utils/self-report-globs.ts
+++ b/src/scanner/inclusive/utils/self-report-globs.ts
@@ -1,0 +1,12 @@
+/**
+ * Glob patterns matching quaid-scanner's own dated scan reports.
+ *
+ * Inclusive scanners must exclude these so they don't ingest their own prior
+ * output (#169 for .md, #207 for .html). Centralized here so adding a new
+ * report format only touches one file.
+ */
+export const SELF_REPORT_GLOBS: readonly string[] = [
+  '**/quaid-scan-*.md',
+  '**/quaid-scan-*.json',
+  '**/quaid-scan-*.html',
+];

--- a/tests/scanner/inclusive/diminishing-scanner.test.ts
+++ b/tests/scanner/inclusive/diminishing-scanner.test.ts
@@ -617,6 +617,26 @@ describe('DiminishingLanguageScanner', () => {
       expect(reportFindings).toHaveLength(0);
     });
 
+    // Regression: #207 — the .html report format added in #200 was not added to the
+    // self-report exclusion list, so scanners ingested their own prior HTML reports.
+    it('produces zero diminishing-language findings for a quaid-scan-*.html report file (#207)', async () => {
+      mkdirSync(join(tmpDir, 'docs', 'reports'), { recursive: true });
+      writeFileSync(
+        join(tmpDir, 'docs', 'reports', 'quaid-scan-2026-06-08.html'),
+        '<!DOCTYPE html><html><body>It is easy to see issues. Just run the scanner again.</body></html>\n',
+      );
+
+      const context = createContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const reportFindings = findings.filter(
+        (f) =>
+          f.file?.startsWith('docs/reports/quaid-scan-') &&
+          f.category === 'diminishing-language',
+      );
+      expect(reportFindings).toHaveLength(0);
+    });
+
     it('produces zero diminishing-language findings for a quaid-scan-*.json report file', async () => {
       // Arrange: JSON report containing diminishing language in its text
       mkdirSync(join(tmpDir, 'docs', 'reports'), { recursive: true });

--- a/tests/scanner/inclusive/doc-scanner.test.ts
+++ b/tests/scanner/inclusive/doc-scanner.test.ts
@@ -564,6 +564,24 @@ describe('InclusiveDocScanner', () => {
       expect(reportFindings).toHaveLength(0);
     });
 
+    // Regression: #207 — the .html report format added in #200 was not added to the
+    // self-report exclusion list, so scanners ingested their own prior HTML reports.
+    it('produces zero findings for a quaid-scan-*.html report file containing flagged terms (#207)', async () => {
+      writeFixture(
+        tmpDir,
+        'docs/reports/quaid-scan-2026-06-08.html',
+        '<!DOCTYPE html><html><body>Non-inclusive term "master" found in src/app.ts</body></html>\n',
+      );
+
+      const context = createScanContext(tmpDir);
+      const findings = await scanner.run(context);
+
+      const reportFindings = findings.filter((f) =>
+        f.file?.startsWith('docs/reports/quaid-scan-'),
+      );
+      expect(reportFindings).toHaveLength(0);
+    });
+
     it('produces zero findings for a quaid-scan-*.json report file containing flagged terms', async () => {
       // Arrange: write a JSON report file that contains a non-inclusive term
       // doc-scanner walks .md/.txt/.rst/.adoc/.html — not .json,


### PR DESCRIPTION
## Summary

Regression from #200 (HTML report renderer). The inclusive scanners' self-report exclusion list — added in #169 to stop scanners ingesting their own prior output — was updated to skip `.md` and `.json` reports but not the new `.html` format. Every rescan therefore ingested the prior `quaid-scan-*.html` and re-flagged every non-inclusive term inside the report *as report text*.

Concrete impact in the ai-kit smoke test:
- 616 findings / 460 WARNING — up from 212 / 78 on the prior scan
- 382 of the 460 WARNINGs came from a single self-ingested `quaid-scan-2026-06-06.html`
- Removing those self-matches gives back the prior 78-warning count

## Fix

- New shared constant `SELF_REPORT_GLOBS` in `src/scanner/inclusive/utils/self-report-globs.ts`:
  ```ts
  ['**/quaid-scan-*.md', '**/quaid-scan-*.json', '**/quaid-scan-*.html']
  ```
- `src/scanner/inclusive/doc-scanner.ts` and `src/scanner/inclusive/diminishing-scanner.ts` now import from this single source of truth.
- Addresses the documented #171 fragmentation in the narrow scope that triggered this regression. Future report formats need to update only one file.

## Test plan

- [x] Regression test in `tests/scanner/inclusive/doc-scanner.test.ts` — `quaid-scan-*.html` containing a flagged term must produce zero findings under `docs/reports/`
- [x] Regression test in `tests/scanner/inclusive/diminishing-scanner.test.ts` — same shape, diminishing-language path
- [x] Red commit (`142598d`) confirmed both tests fail before fix
- [x] Existing `.md` and `.json` self-report tests still pass (no regression in #169 behavior)
- [x] Full suite: 1694/1694 passing

Closes #207