### PR TITLE
chore: rewrite .ainative and .claude symlinks to portable relative paths

### DIFF
--- a/.ainative
+++ b/.ainative
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.ainative
+../../AINative-Studio/src/core/.ainative

--- a/.claude/RULES.MD
+++ b/.claude/RULES.MD
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/RULES.MD
+../../../AINative-Studio/src/core/.claude/RULES.MD

--- a/.claude/SYMLINK_SETUP.md
+++ b/.claude/SYMLINK_SETUP.md
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/SYMLINK_SETUP.md
+../../../AINative-Studio/src/core/.claude/SYMLINK_SETUP.md

--- a/.claude/commands
+++ b/.claude/commands
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/commands
+../../../AINative-Studio/src/core/.claude/commands

--- a/.claude/compressed
+++ b/.claude/compressed
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/compressed
+../../../AINative-Studio/src/core/.claude/compressed

--- a/.claude/hooks
+++ b/.claude/hooks
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/hooks
+../../../AINative-Studio/src/core/.claude/hooks

--- a/.claude/mcp.json.example
+++ b/.claude/mcp.json.example
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/mcp.json.example
+../../../AINative-Studio/src/core/.claude/mcp.json.example

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/settings.json
+../../../AINative-Studio/src/core/.claude/settings.json

--- a/.claude/skills/ainative-agent-framework
+++ b/.claude/skills/ainative-agent-framework
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/ainative-agent-framework
+../../../../AINative-Studio/src/core/.claude/skills/ainative-agent-framework

--- a/.claude/skills/ainative-auth-guide
+++ b/.claude/skills/ainative-auth-guide
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/ainative-auth-guide
+../../../../AINative-Studio/src/core/.claude/skills/ainative-auth-guide

--- a/.claude/skills/ainative-git-workflow
+++ b/.claude/skills/ainative-git-workflow
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/ainative-git-workflow
+../../../../AINative-Studio/src/core/.claude/skills/ainative-git-workflow

--- a/.claude/skills/ainative-mcp-builder
+++ b/.claude/skills/ainative-mcp-builder
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/ainative-mcp-builder
+../../../../AINative-Studio/src/core/.claude/skills/ainative-mcp-builder

--- a/.claude/skills/ainative-nextjs-sdk
+++ b/.claude/skills/ainative-nextjs-sdk
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/ainative-nextjs-sdk
+../../../../AINative-Studio/src/core/.claude/skills/ainative-nextjs-sdk

--- a/.claude/skills/ainative-react-sdk
+++ b/.claude/skills/ainative-react-sdk
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/ainative-react-sdk
+../../../../AINative-Studio/src/core/.claude/skills/ainative-react-sdk

--- a/.claude/skills/ainative-sdk-quickstart
+++ b/.claude/skills/ainative-sdk-quickstart
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/ainative-sdk-quickstart
+../../../../AINative-Studio/src/core/.claude/skills/ainative-sdk-quickstart

--- a/.claude/skills/ainative-svelte-sdk
+++ b/.claude/skills/ainative-svelte-sdk
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/ainative-svelte-sdk
+../../../../AINative-Studio/src/core/.claude/skills/ainative-svelte-sdk

--- a/.claude/skills/ainative-vue-sdk
+++ b/.claude/skills/ainative-vue-sdk
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/ainative-vue-sdk
+../../../../AINative-Studio/src/core/.claude/skills/ainative-vue-sdk

--- a/.claude/skills/api-catalog.md
+++ b/.claude/skills/api-catalog.md
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/api-catalog.md
+../../../../AINative-Studio/src/core/.claude/skills/api-catalog.md

--- a/.claude/skills/api-key-management.md
+++ b/.claude/skills/api-key-management.md
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/api-key-management.md
+../../../../AINative-Studio/src/core/.claude/skills/api-key-management.md

--- a/.claude/skills/api-testing-requirements.md
+++ b/.claude/skills/api-testing-requirements.md
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/api-testing-requirements.md
+../../../../AINative-Studio/src/core/.claude/skills/api-testing-requirements.md

--- a/.claude/skills/audio-transcribe.md
+++ b/.claude/skills/audio-transcribe.md
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/audio-transcribe.md
+../../../../AINative-Studio/src/core/.claude/skills/audio-transcribe.md

--- a/.claude/skills/blog-publish-pipeline
+++ b/.claude/skills/blog-publish-pipeline
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/blog-publish-pipeline
+../../../../AINative-Studio/src/core/.claude/skills/blog-publish-pipeline

--- a/.claude/skills/ci-cd-compliance
+++ b/.claude/skills/ci-cd-compliance
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/ci-cd-compliance
+../../../../AINative-Studio/src/core/.claude/skills/ci-cd-compliance

--- a/.claude/skills/code-quality
+++ b/.claude/skills/code-quality
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/code-quality
+../../../../AINative-Studio/src/core/.claude/skills/code-quality

--- a/.claude/skills/daily-report.md
+++ b/.claude/skills/daily-report.md
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/daily-report.md
+../../../../AINative-Studio/src/core/.claude/skills/daily-report.md

--- a/.claude/skills/database-query-best-practices
+++ b/.claude/skills/database-query-best-practices
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/database-query-best-practices
+../../../../AINative-Studio/src/core/.claude/skills/database-query-best-practices

--- a/.claude/skills/database-schema-sync
+++ b/.claude/skills/database-schema-sync
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/database-schema-sync
+../../../../AINative-Studio/src/core/.claude/skills/database-schema-sync

--- a/.claude/skills/delivery-checklist
+++ b/.claude/skills/delivery-checklist
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/delivery-checklist
+../../../../AINative-Studio/src/core/.claude/skills/delivery-checklist

--- a/.claude/skills/echo-developer-guide
+++ b/.claude/skills/echo-developer-guide
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/echo-developer-guide
+../../../../AINative-Studio/src/core/.claude/skills/echo-developer-guide

--- a/.claude/skills/email-campaign-management
+++ b/.claude/skills/email-campaign-management
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/email-campaign-management
+../../../../AINative-Studio/src/core/.claude/skills/email-campaign-management

--- a/.claude/skills/file-placement
+++ b/.claude/skills/file-placement
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/file-placement
+../../../../AINative-Studio/src/core/.claude/skills/file-placement

--- a/.claude/skills/git-workflow
+++ b/.claude/skills/git-workflow
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/git-workflow
+../../../../AINative-Studio/src/core/.claude/skills/git-workflow

--- a/.claude/skills/huggingface-deployment
+++ b/.claude/skills/huggingface-deployment
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/huggingface-deployment
+../../../../AINative-Studio/src/core/.claude/skills/huggingface-deployment

--- a/.claude/skills/kong-gateway.md
+++ b/.claude/skills/kong-gateway.md
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/kong-gateway.md
+../../../../AINative-Studio/src/core/.claude/skills/kong-gateway.md

--- a/.claude/skills/mandatory-tdd
+++ b/.claude/skills/mandatory-tdd
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/mandatory-tdd
+../../../../AINative-Studio/src/core/.claude/skills/mandatory-tdd

--- a/.claude/skills/openclaw-integration
+++ b/.claude/skills/openclaw-integration
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/openclaw-integration
+../../../../AINative-Studio/src/core/.claude/skills/openclaw-integration

--- a/.claude/skills/parallel-worktrees
+++ b/.claude/skills/parallel-worktrees
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/parallel-worktrees
+../../../../AINative-Studio/src/core/.claude/skills/parallel-worktrees

--- a/.claude/skills/port-management
+++ b/.claude/skills/port-management
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/port-management
+../../../../AINative-Studio/src/core/.claude/skills/port-management

--- a/.claude/skills/story-workflow
+++ b/.claude/skills/story-workflow
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/story-workflow
+../../../../AINative-Studio/src/core/.claude/skills/story-workflow

--- a/.claude/skills/strapi-blog-image-unique
+++ b/.claude/skills/strapi-blog-image-unique
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/strapi-blog-image-unique
+../../../../AINative-Studio/src/core/.claude/skills/strapi-blog-image-unique

--- a/.claude/skills/strapi-blog-slug-mandatory
+++ b/.claude/skills/strapi-blog-slug-mandatory
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/strapi-blog-slug-mandatory
+../../../../AINative-Studio/src/core/.claude/skills/strapi-blog-slug-mandatory

--- a/.claude/skills/weekly-report
+++ b/.claude/skills/weekly-report
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/weekly-report
+../../../../AINative-Studio/src/core/.claude/skills/weekly-report

--- a/.claude/skills/zerodb-cli
+++ b/.claude/skills/zerodb-cli
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/zerodb-cli
+../../../../AINative-Studio/src/core/.claude/skills/zerodb-cli

--- a/.claude/skills/zerodb-mcp-guide
+++ b/.claude/skills/zerodb-mcp-guide
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/zerodb-mcp-guide
+../../../../AINative-Studio/src/core/.claude/skills/zerodb-mcp-guide

--- a/.claude/skills/zeromemory-guide
+++ b/.claude/skills/zeromemory-guide
@@ -1,1 +1,1 @@
-/Users/karstenwade/Projects/AINative-Studio/src/core/.claude/skills/zeromemory-guide
+../../../../AINative-Studio/src/core/.claude/skills/zeromemory-guide


### PR DESCRIPTION
## Summary

- Rewrite 45 previously-macOS-absolute symlinks (`.ainative` + everything under `.claude/`) to relative paths that resolve on both macOS and Linux, since `~/Projects/AINative-Studio/src` and `~/Projects/github-quaid/quaid-scanner` share the same relative layout on both machines.
- Restores agent access to the fresh `core/.claude/skills/` content from within this project instead of falling back to a stale `~/.claude/skills/` global copy.
- One symlink (`.claude/skills/blog-publish-pipeline`) still points to a target that has never existed in core; tracked separately in #211.

## Test plan

- [x] `find . -maxdepth 4 -type l` shows only one still-dangling symlink (`blog-publish-pipeline`), whose target has never existed anywhere and is tracked in #211
- [x] `ls .ainative/skills/` and `ls .claude/skills/mandatory-tdd/` both resolve to fresh core content
- [x] Symlink targets remain equivalent on macOS (relative form resolves to the same location the old absolute form did)
- [ ] Verify on macOS after merge that no symlinks broke there

No README update needed — internal tooling symlink cleanup, no user-visible change.